### PR TITLE
Always run `onElementClick` if provided, regardless of `isSelectable` or `isDraggable`

### DIFF
--- a/cypress/integration/flow/interaction.spec.js
+++ b/cypress/integration/flow/interaction.spec.js
@@ -12,12 +12,12 @@ describe('Interaction Flow Rendering', () => {
 
   it('tries to select a node by click', () => {
     const pointerEvents = Cypress.$('.react-flow__node:first').css('pointer-events');
-    expect(pointerEvents).to.equal('none');
+    expect(pointerEvents).to.equal('all');
   });
 
   it('tries to select an edge by click', () => {
     const pointerEvents = Cypress.$('.react-flow__edge:first').css('pointer-events');
-    expect(pointerEvents).to.equal('none');
+    expect(pointerEvents).to.equal('all');
   });
 
   it('tries to do a selection', () => {

--- a/cypress/integration/flow/interaction.spec.js
+++ b/cypress/integration/flow/interaction.spec.js
@@ -12,10 +12,24 @@ describe('Interaction Flow Rendering', () => {
 
   it('tries to select a node by click', () => {
     const pointerEvents = Cypress.$('.react-flow__node:first').css('pointer-events');
-    expect(pointerEvents).to.equal('all');
+    expect(pointerEvents).to.equal('none');
   });
 
   it('tries to select an edge by click', () => {
+    const pointerEvents = Cypress.$('.react-flow__edge:first').css('pointer-events');
+    expect(pointerEvents).to.equal('none');
+  });
+
+  it('toggles on capture element click', () => {
+    cy.get('.react-flow__captureelementclick').click();
+  });
+
+  it('allows node clicks when enabled', () => {
+    const pointerEvents = Cypress.$('.react-flow__node:first').css('pointer-events');
+    expect(pointerEvents).to.equal('all');
+  });
+
+  it('allows edge clicks when enabled', () => {
     const pointerEvents = Cypress.$('.react-flow__edge:first').css('pointer-events');
     expect(pointerEvents).to.equal('all');
   });

--- a/example/src/Interaction/index.js
+++ b/example/src/Interaction/index.js
@@ -28,6 +28,7 @@ const InteractionFlow = () => {
   const [zoomOnDoubleClick, setZoomOnDoubleClick] = useState(false);
   const [paneMoveable, setPaneMoveable] = useState(true);
   const [captureZoomClick, setCaptureZoomClick] = useState(false);
+  const [captureElementClick, setCaptureElementClick] = useState(false);
 
   return (
     <ReactFlow
@@ -38,7 +39,7 @@ const InteractionFlow = () => {
       zoomOnScroll={zoomOnScroll}
       zoomOnDoubleClick={zoomOnDoubleClick}
       onConnect={onConnect}
-      onElementClick={onElementClick}
+      onElementClick={captureElementClick ? onElementClick : undefined}
       onNodeDragStart={onNodeDragStart}
       onNodeDragStop={onNodeDragStop}
       paneMoveable={paneMoveable}
@@ -130,6 +131,18 @@ const InteractionFlow = () => {
               checked={captureZoomClick}
               onChange={(event) => setCaptureZoomClick(event.target.checked)}
               className="react-flow__capturezoompaneclick"
+            />
+          </label>
+        </div>
+        <div>
+          <label htmlFor="captureelementclick">
+            capture element click
+            <input
+              id="captureelementclick"
+              type="checkbox"
+              checked={captureElementClick}
+              onChange={(event) => setCaptureElementClick(event.target.checked)}
+              className="react-flow__captureelementclick"
             />
           </label>
         </div>

--- a/src/components/Edges/wrapEdge.tsx
+++ b/src/components/Edges/wrapEdge.tsx
@@ -53,14 +53,12 @@ export default (EdgeComponent: ComponentType<EdgeCompProps>) => {
 
     const edgeClasses = cc(['react-flow__edge', `react-flow__edge-${type}`, className, { selected, animated }]);
     const edgeGroupStyle: CSSProperties = {
-      pointerEvents: elementsSelectable ? 'all' : 'none',
+      pointerEvents: elementsSelectable || onClick ? 'all' : 'none',
     };
     const onEdgeClick = (event: React.MouseEvent<SVGGElement, MouseEvent>): void => {
-      if (!elementsSelectable) {
-        return;
+      if (elementsSelectable) {
+        setSelectedElements({ id, source, target });
       }
-
-      setSelectedElements({ id, source, target });
 
       if (onClick) {
         const edgeElement: Edge = { id, source, target, type };

--- a/src/components/Nodes/wrapNode.tsx
+++ b/src/components/Nodes/wrapNode.tsx
@@ -241,10 +241,10 @@ export default (NodeComponent: ComponentType<NodeComponentProps>) => {
       (event: MouseEvent) => {
         if (!isDraggable && isSelectable) {
           setSelectedElements({ id: node.id, type: node.type } as Node);
+        }
 
-          if (onClick) {
-            onClick(event, node);
-          }
+        if (onClick) {
+          onClick(event, node);
         }
       },
       [isSelectable, isDraggable, node]
@@ -279,7 +279,7 @@ export default (NodeComponent: ComponentType<NodeComponentProps>) => {
     const nodeStyle: CSSProperties = {
       zIndex: selected ? 10 : 3,
       transform: `translate(${xPos}px,${yPos}px)`,
-      pointerEvents: isSelectable || isDraggable ? 'all' : 'none',
+      pointerEvents: isSelectable || isDraggable || onClick ? 'all' : 'none',
       ...style,
     };
 


### PR DESCRIPTION
It would be useful to have the `onElementClick` event run, even if elements are not selectable or draggable. 