### PR TITLE
Expose getConnectedEdge + Set className of minimap node

### DIFF
--- a/src/additional-components/MiniMap/MiniMapNode.tsx
+++ b/src/additional-components/MiniMap/MiniMapNode.tsx
@@ -6,17 +6,18 @@ interface MiniMapNodeProps {
   width: number;
   height: number;
   color: string;
+  className: string;
   borderRadius: number;
   style?: CSSProperties;
 }
 
-const MiniMapNode = ({ x, y, width, height, style, color, borderRadius }: MiniMapNodeProps) => {
+const MiniMapNode = ({ x, y, width, height, style, color, className, borderRadius }: MiniMapNodeProps) => {
   const { background, backgroundColor } = style || {};
   const fill = (color || background || backgroundColor) as string;
 
   return (
     <rect
-      className="react-flow__minimap-node"
+      className={`react-flow__minimap-node ${className}`}
       x={x}
       y={y}
       rx={borderRadius}

--- a/src/additional-components/MiniMap/MiniMapNode.tsx
+++ b/src/additional-components/MiniMap/MiniMapNode.tsx
@@ -1,4 +1,5 @@
 import React, { memo, CSSProperties } from 'react';
+import cc from 'classcat';
 
 interface MiniMapNodeProps {
   x: number;
@@ -17,7 +18,7 @@ const MiniMapNode = ({ x, y, width, height, style, color, className, borderRadiu
 
   return (
     <rect
-      className={`react-flow__minimap-node ${className}`}
+      className={cc(['react-flow__minimap-node', className])}
       x={x}
       y={y}
       rx={borderRadius}

--- a/src/additional-components/MiniMap/index.tsx
+++ b/src/additional-components/MiniMap/index.tsx
@@ -12,6 +12,7 @@ type StringFunc = (node: Node) => string;
 
 interface MiniMapProps extends React.HTMLAttributes<SVGSVGElement> {
   nodeColor?: string | StringFunc;
+  nodeClassName?: string | StringFunc;
   nodeBorderRadius?: number;
   maskColor?: string;
 }
@@ -23,6 +24,7 @@ const MiniMap = ({
   style = { backgroundColor: '#f8f8f8' },
   className,
   nodeColor = '#ddd',
+  nodeClassName = '',
   nodeBorderRadius = 5,
   maskColor = 'rgba(10, 10, 10, .25)',
 }: MiniMapProps) => {
@@ -35,6 +37,7 @@ const MiniMap = ({
   const elementWidth = (style.width || defaultWidth)! as number;
   const elementHeight = (style.height || defaultHeight)! as number;
   const nodeColorFunc = (nodeColor instanceof Function ? nodeColor : () => nodeColor) as StringFunc;
+  const nodeClassNameFunc = (nodeClassName instanceof Function ? nodeClassName : () => nodeClassName) as StringFunc;
   const hasNodes = nodes && nodes.length;
   const bb = getRectOfNodes(nodes);
   const viewBB: Rect = {
@@ -73,6 +76,7 @@ const MiniMap = ({
             width={node.__rf.width}
             height={node.__rf.height}
             style={node.style}
+            className={nodeClassNameFunc(node)}
             color={nodeColorFunc(node)}
             borderRadius={nodeBorderRadius}
           />

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ export { getBezierPath } from './components/Edges/BezierEdge';
 export { getSmoothStepPath } from './components/Edges/SmoothStepEdge';
 export { getMarkerEnd, getCenter as getEdgeCenter } from './components/Edges/utils';
 
-export { isNode, isEdge, removeElements, addEdge, getOutgoers } from './utils/graph';
+export { isNode, isEdge, removeElements, addEdge, getOutgoers, getConnectedEdges } from './utils/graph';
 
 export * from './additional-components';
 export * from './types';


### PR DESCRIPTION
Hi,

We exposed `getConnectedEdge` as it met exactly our needs but it wasn't exported, even though it is very easy to use.

We also added a `nodeClassName?: StringFunc | string` prop to the `MiniMap` component to pass a custom class name to the nodes, with the possibility to customize it for each individual node.
In our case we needed this to display each node in the same color in the pane and in the minimap directly from the SCSS.
Before this change we could only do this through JS which forced us to duplicate the color palette in SCSS and JS.

I have to warn you that I was not able to run all tests locally, as it first complained about missing a very specific version of eslint (which I had to install manually), then that it could not find React in the compiled files, even though it was obviously present in the node_modules. I'm not sure what I did wrong, `npm i` and `npm test` did not work.
Please bear with me if I broke any tests 😅