### PR TITLE
fix: Set border-box explicitly on Controls

### DIFF
--- a/src/additional-components/Controls/style.css
+++ b/src/additional-components/Controls/style.css
@@ -8,6 +8,7 @@
   &-button {
     background: #fefefe;
     border-bottom: 1px solid #eee;
+    box-sizing: content-box;
     display: flex;
     justify-content: center;
     align-items: center;


### PR DESCRIPTION
Set border-box explicitly so upstream frameworks don't upset the layout.