### PR TITLE
Update example README.md

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -3,6 +3,7 @@
 The examples are deployed here: https://reactflow.dev/
 
 ### Installation
+After running `npm install` first in the top-level project directory:
 
 ```
 npm install


### PR DESCRIPTION
Add note about needing to NPM install in the top-level project before running the examples. If this isn't run some deps (like react) are missing and the `npm start` command will fail.