### PR TITLE
Modify node wrapper to update pin state if the child list mutates, or…

### DIFF
--- a/src/components/Nodes/wrapNode.tsx
+++ b/src/components/Nodes/wrapNode.tsx
@@ -37,6 +37,7 @@ export default (NodeComponent: ComponentType<NodeComponentProps>) => {
     snapGrid,
     isDragging,
     resizeObserver,
+    mutationObserver,
   }: WrapNodeProps) => {
     const updateNodeDimensions = useStoreActions((actions) => actions.updateNodeDimensions);
     const addSelectedElements = useStoreActions((actions) => actions.addSelectedElements);
@@ -176,10 +177,15 @@ export default (NodeComponent: ComponentType<NodeComponentProps>) => {
 
     useEffect(() => {
       if (nodeElement.current) {
+        const config = { attributes: false, childList: true, subtree: true };
         const currNode = nodeElement.current;
         resizeObserver?.observe(currNode);
+        mutationObserver?.observe(currNode, config);
 
-        return () => resizeObserver?.unobserve(currNode);
+        return () => {
+          resizeObserver?.unobserve(currNode);
+          mutationObserver?.disconnect();
+        }
       }
 
       return;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -39,6 +39,15 @@ type NodeDimensionUpdates = {
   updates: NodeDimensionUpdate[];
 };
 
+type HandleUpdate = {
+  id: ElementId;
+  nodeElement: HTMLDivElement;
+}
+
+type HandleUpdates = {
+  updates: HandleUpdate[];
+}
+
 type InitD3Zoom = {
   d3Zoom: ZoomBehavior<Element, unknown>;
   d3Selection: D3Selection<Element, unknown, null, undefined>;
@@ -98,6 +107,8 @@ export interface StoreModel {
   setOnConnectEnd: Action<StoreModel, OnConnectEndFunc>;
 
   setElements: Action<StoreModel, Elements>;
+
+  batchUpdateHandles: Action<StoreModel, HandleUpdates>;
 
   batchUpdateNodeDimensions: Action<StoreModel, NodeDimensionUpdates>;
   updateNodeDimensions: Action<StoreModel, NodeDimensionUpdate>;
@@ -265,6 +276,15 @@ export const storeModel: StoreModel = {
         // add new element
         state.elements.push(parseElement(el, state.nodeExtent));
       }
+    });
+  }),
+
+  batchUpdateHandles: action((state, { updates }) => {
+    updates.forEach((update) => {
+      const matchingIndex = state.elements.findIndex((n) => n.id === update.id);
+      const handleBounds = getHandleBounds(update.nodeElement, state.transform[2]);
+
+      (state.elements[matchingIndex] as Node).__rf.handleBounds = handleBounds;
     });
   }),
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -232,6 +232,7 @@ export interface WrapNodeProps<T = any> {
   snapGrid?: SnapGrid;
   isDragging?: boolean;
   resizeObserver: ResizeObserver | null;
+  mutationObserver: MutationObserver | null;
 }
 
 export type FitViewParams = {


### PR DESCRIPTION
… if the subchildren mutate. Only update pin state on this occurrence as resize is already handled elsewhere.

Fixes an issue discussed on #805 where updating the ids for handles under a node would not propagate the new handle layout unless a resize event occurred.  This is handled by adding a MutationObserver to the nodes root element, and setting handleBounds each time a mutation event within the nodes element tree is observed.