### PR TITLE
Add a layout mutation hook for updating user blocks on change

### DIFF
--- a/src/hooks/useNodeLayoutEffect.ts
+++ b/src/hooks/useNodeLayoutEffect.ts
@@ -1,0 +1,13 @@
+import {MutableRefObject, useLayoutEffect} from "react";
+import {useStoreActions} from "../store/hooks";
+import {ElementId} from "../types";
+
+export default (id: ElementId, nodeElement: MutableRefObject<HTMLDivElement | null>) => {
+    const updateNodeDimensions = useStoreActions((actions) => actions.updateNodeDimensions);
+
+    useLayoutEffect(() => {
+        if (nodeElement.current) {
+            updateNodeDimensions([{id, nodeElement: nodeElement.current, forceUpdate: true}]);
+        }
+    });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ export {
   updateEdge,
 } from './utils/graph';
 export { default as useZoomPanHelper } from './hooks/useZoomPanHelper';
+export { default as useNodeLayoutEffect } from './hooks/useNodeLayoutEffect';
 
 export * from './additional-components';
 export * from './store/hooks';


### PR DESCRIPTION
This change adds an effect hook which triggers an update to the blocks pin positions every time the layout of component it is registered to is mutated.  When used within a block that mutates its own state, fixes #805.  Supersedes #859, where it was discovered that diagram global mutation observation is detrimental to performance.