### PR TITLE
Fixed minimap node borders on Safari, Chrome, etc

### DIFF
--- a/src/additional-components/MiniMap/MiniMapNode.tsx
+++ b/src/additional-components/MiniMap/MiniMapNode.tsx
@@ -9,6 +9,7 @@ interface MiniMapNodeProps {
   borderRadius: number;
   className: string;
   color: string;
+  shapeRendering: string;
   strokeColor: string;
   strokeWidth: number;
   style?: CSSProperties;
@@ -25,6 +26,7 @@ const MiniMapNode = ({
   strokeWidth,
   className,
   borderRadius,
+  shapeRendering
 }: MiniMapNodeProps) => {
   const { background, backgroundColor } = style || {};
   const fill = (color || background || backgroundColor) as string;
@@ -41,6 +43,7 @@ const MiniMapNode = ({
       fill={fill}
       stroke={strokeColor}
       strokeWidth={strokeWidth}
+      shapeRendering={shapeRendering}
     />
   );
 };

--- a/src/additional-components/MiniMap/index.tsx
+++ b/src/additional-components/MiniMap/index.tsx
@@ -64,7 +64,7 @@ const MiniMap = ({
   const y = boundingRect.y - (viewHeight - boundingRect.height) / 2 - offset;
   const width = viewWidth + offset * 2;
   const height = viewHeight + offset * 2;
-  const shapeRendering = !!window.chrome ?  "crispEdges" : "geometricPrecision";
+  const shapeRendering = (typeof window === "undefined" || !!window.chrome) ?  "crispEdges" : "geometricPrecision";
 
   return (
     <svg

--- a/src/additional-components/MiniMap/index.tsx
+++ b/src/additional-components/MiniMap/index.tsx
@@ -17,6 +17,8 @@ export interface MiniMapProps extends HTMLAttributes<SVGSVGElement> {
   maskColor?: string;
 }
 
+declare const window: any;
+
 const defaultWidth = 200;
 const defaultHeight = 150;
 
@@ -62,6 +64,7 @@ const MiniMap = ({
   const y = boundingRect.y - (viewHeight - boundingRect.height) / 2 - offset;
   const width = viewWidth + offset * 2;
   const height = viewHeight + offset * 2;
+  const shapeRendering = !!window.chrome ?  "crispEdges" : "geometricPrecision";
 
   return (
     <svg
@@ -86,6 +89,7 @@ const MiniMap = ({
             borderRadius={nodeBorderRadius}
             strokeColor={nodeStrokeColorFunc(node)}
             strokeWidth={nodeStrokeWidth}
+            shapeRendering={shapeRendering}
           />
         ))}
       <path

--- a/src/style.css
+++ b/src/style.css
@@ -178,8 +178,4 @@
   z-index: 5;
   bottom: 10px;
   right: 10px;
-
-  &-node {
-    shape-rendering: crispedges;
-  }
 }


### PR DESCRIPTION
Borders from the nodes on the minimap would clip terribly on non-Chrome browsers. This was caused by them having the css `shape-rendering: crispedges;`. Changing this to `shape-rendering: geometricPrecision;` fixes the issue on non-Chrome browsers but breaks it on Chrome.
Example:
Chrome:
![Chrome](https://user-images.githubusercontent.com/8900389/114867371-03216280-9df5-11eb-9899-b46da2e68765.png)
Firfox:
![Firefox](https://user-images.githubusercontent.com/8900389/114867373-03b9f900-9df5-11eb-9ee9-cf80f1b1aca3.png)
Removing the CSS and instead moving the `shapeRendering` directly into the SVG-element allows us to first check if a user is using Chrome or not. If a user is using Chrome we still use `crispEdges`, else we can use `geometricPrecision`.