### PR TITLE
fix(edge): change order of the first EdgeAnchor disturbed by the EdgeComponent

### DIFF
--- a/src/components/Edges/wrapEdge.tsx
+++ b/src/components/Edges/wrapEdge.tsx
@@ -184,15 +184,6 @@ export default (EdgeComponent: ComponentType<EdgeProps>) => {
         onMouseMove={onEdgeMouseMove}
         onMouseLeave={onEdgeMouseLeave}
       >
-        {handleEdgeUpdate && (
-          <g
-            onMouseDown={onEdgeUpdaterSourceMouseDown}
-            onMouseEnter={onEdgeUpdaterMouseEnter}
-            onMouseOut={onEdgeUpdaterMouseOut}
-          >
-            <EdgeAnchor position={sourcePosition} centerX={sourceX} centerY={sourceY} radius={edgeUpdaterRadius} />
-          </g>
-        )}
         <EdgeComponent
           id={id}
           source={source}
@@ -218,6 +209,15 @@ export default (EdgeComponent: ComponentType<EdgeProps>) => {
           sourceHandleId={sourceHandleId}
           targetHandleId={targetHandleId}
         />
+        {handleEdgeUpdate && (
+          <g
+            onMouseDown={onEdgeUpdaterSourceMouseDown}
+            onMouseEnter={onEdgeUpdaterMouseEnter}
+            onMouseOut={onEdgeUpdaterMouseOut}
+          >
+            <EdgeAnchor position={sourcePosition} centerX={sourceX} centerY={sourceY} radius={edgeUpdaterRadius} />
+          </g>
+        )}
         {handleEdgeUpdate && (
           <g
             onMouseDown={onEdgeUpdaterTargetMouseDown}

--- a/src/style.css
+++ b/src/style.css
@@ -42,7 +42,7 @@
 }
 
 .react-flow__edge {
-  pointer-events: all;
+  pointer-events: visibleStroke;
 
   &.inactive {
     pointer-events: none;
@@ -145,6 +145,7 @@
 
 .react-flow__edgeupdater {
   cursor: move;
+  pointer-events: all;
 }
 
 /* additional components */


### PR DESCRIPTION
<img width="632" alt="Capture d’écran 2021-04-22 à 10 01 01" src="https://user-images.githubusercontent.com/15263596/115670157-c3f19500-a351-11eb-9b4a-dac7aab9d449.png">

### Problem

The first EdgeAnchor is disturbed by the EdgeComponent (the line). To demonstrate this, you can see on the screenshot, if we fill the line path and the circle of the edge anchor, the red one cannot be dragged because the line path goes under it.

### Solution

On the `wrapEdge` file, I just change the order of the svg elements. Like this anchors are always on the top.