### PR TITLE
Feature: poc for boolean selectionKeyCode

### DIFF
--- a/src/container/FlowRenderer/index.tsx
+++ b/src/container/FlowRenderer/index.tsx
@@ -58,7 +58,9 @@ const FlowRenderer = ({
   const resetSelectedElements = useStoreActions((actions) => actions.resetSelectedElements);
   const nodesSelectionActive = useStoreState((state) => state.nodesSelectionActive);
 
-  const selectionKeyPressed = useKeyPress(selectionKeyCode);
+  const selectionKeyPressed = (typeof selectionKeyCode === 'boolean')
+    ? selectionKeyCode
+    : useKeyPress(selectionKeyCode);
 
   useGlobalKeyHandler({ onElementsRemove, deleteKeyCode, multiSelectionKeyCode });
 

--- a/src/container/GraphView/index.tsx
+++ b/src/container/GraphView/index.tsx
@@ -14,7 +14,7 @@ import { NodeTypesType, EdgeTypesType, ConnectionLineType, KeyCode } from '../..
 export interface GraphViewProps extends Omit<ReactFlowProps, 'onSelectionChange' | 'elements'> {
   nodeTypes: NodeTypesType;
   edgeTypes: EdgeTypesType;
-  selectionKeyCode: KeyCode;
+  selectionKeyCode: KeyCode | boolean;
   deleteKeyCode: KeyCode;
   multiSelectionKeyCode: KeyCode;
   connectionLineType: ConnectionLineType;

--- a/src/container/ReactFlow/index.tsx
+++ b/src/container/ReactFlow/index.tsx
@@ -84,7 +84,7 @@ export interface ReactFlowProps extends Omit<HTMLAttributes<HTMLDivElement>, 'on
   connectionLineStyle?: CSSProperties;
   connectionLineComponent?: ConnectionLineComponent;
   deleteKeyCode?: KeyCode;
-  selectionKeyCode?: KeyCode;
+  selectionKeyCode?: KeyCode | boolean;
   multiSelectionKeyCode?: KeyCode;
   zoomActivationKeyCode?: KeyCode;
   snapToGrid?: boolean;


### PR DESCRIPTION
Not necessarily the way maintainers of this library might want to do it, but I have a similar use case as #1001 and #964 and whipped up a proof of concept. 

My use case is I'm basically trying to create a toolbar where instead of holding down a key, you would click a button to activate the "box drag select" state (think photoshop toolbarish sort of thing)
 
In this situation, I needed to be able to pass true and false instead of just simply something like null. I guess I could have just made the keycode something obscure but it feels clearer to have something that specifically disables the box select when desired to be disabled.