### PR TITLE
Examples - Drag and Drop - Passing node properties when dragging from sidebar

### DIFF
--- a/example/src/DragNDrop/Sidebar.tsx
+++ b/example/src/DragNDrop/Sidebar.tsx
@@ -1,7 +1,7 @@
 import React, { DragEvent } from 'react';
 
-const onDragStart = (event: DragEvent, nodeType: string) => {
-  event.dataTransfer.setData('application/reactflow', nodeType);
+const onDragStart = (event: DragEvent, nodeData: object) => {
+  event.dataTransfer.setData('application/reactflow', JSON.stringify(nodeData));
   event.dataTransfer.effectAllowed = 'move';
 };
 
@@ -9,13 +9,13 @@ const Sidebar = () => {
   return (
     <aside>
       <div className="description">You can drag these nodes to the pane on the right.</div>
-      <div className="dndnode input" onDragStart={(event: DragEvent) => onDragStart(event, 'input')} draggable>
+      <div className="dndnode input" onDragStart={(event: DragEvent) => onDragStart(event, { nodeType: "input", label: "Input Node" })} draggable>
         Input Node
       </div>
-      <div className="dndnode" onDragStart={(event: DragEvent) => onDragStart(event, 'default')} draggable>
+      <div className="dndnode" onDragStart={(event: DragEvent) => onDragStart(event, { nodeType: "default", label: "Default Node" })} draggable>
         Default Node
       </div>
-      <div className="dndnode output" onDragStart={(event: DragEvent) => onDragStart(event, 'output')} draggable>
+      <div className="dndnode output" onDragStart={(event: DragEvent) => onDragStart(event, { nodeType: "output", label: "Output Node" })} draggable>
         Output Node
       </div>
     </aside>

--- a/example/src/DragNDrop/index.tsx
+++ b/example/src/DragNDrop/index.tsx
@@ -38,13 +38,13 @@ const DnDFlow = () => {
     event.preventDefault();
 
     if (reactFlowInstance) {
-      const type = event.dataTransfer.getData('application/reactflow');
+      const nodeData = JSON.parse(event.dataTransfer.getData('application/reactflow'));
       const position = reactFlowInstance.project({ x: event.clientX, y: event.clientY - 40 });
       const newNode: Node = {
         id: getId(),
-        type,
+        type: nodeData.nodeType,
         position,
-        data: { label: `${type} node` },
+        data: nodeData,
       };
 
       setElements((es) => es.concat(newNode));


### PR DESCRIPTION
This allows instantiating parametrized custom nodes.