### PR TITLE
BUG FIX: should support react-dom 16 and 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "peerDependencies": {
     "react": "16 || 17",
-    "react-dom": "17 || 17"
+    "react-dom": "16 || 17"
   },
   "files": [
     "dist",


### PR DESCRIPTION
## Description
The version of the peer dependency `react-dom` should be `16 || 17` instead of `17 || 17`. This bug prevents projects using React Dom 16 from installing version `9.6.3`.

## References
Right version (9.6.0): https://github.com/wbkd/react-flow/commit/f835f85e65545ac87eb5bd2247a4ea1ebaee85ec
Changed to 17 only (9.6.1 ?): https://github.com/wbkd/react-flow/commit/290ba99f7048c04687255e4ff2cb175675d5432f
Got typo when you changed it back (9.6.3): https://github.com/wbkd/react-flow/commit/8c4ae0cb5deda608b990df7cf9c900baac3245e0

## How Has This Been Tested?
This haven't been tested yet, but it should work 😄