### PR TITLE
Extend Connection Lines

### DIFF
--- a/src/components/ConnectionLine/index.tsx
+++ b/src/components/ConnectionLine/index.tsx
@@ -79,6 +79,8 @@ export default ({
           targetPosition={targetPosition}
           connectionLineType={connectionLineType}
           connectionLineStyle={connectionLineStyle}
+          sourceNode={sourceNode}
+          sourceHandle={sourceHandle}
         />
       </g>
     );

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -303,6 +303,8 @@ export type ConnectionLineComponentProps = {
   targetPosition?: Position;
   connectionLineStyle?: CSSProperties;
   connectionLineType: ConnectionLineType;
+  sourceNode?: Node | null;
+  sourceHandle?: HandleElement;
 };
 
 export type ConnectionLineComponent = React.ComponentType<ConnectionLineComponentProps>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -303,7 +303,7 @@ export type ConnectionLineComponentProps = {
   targetPosition?: Position;
   connectionLineStyle?: CSSProperties;
   connectionLineType: ConnectionLineType;
-  sourceNode?: Node | null;
+  sourceNode?: Node;
   sourceHandle?: HandleElement;
 };
 


### PR DESCRIPTION
Include Node and Handle in props passed to custom connection lines for advanced usage.

I created advanced label handles for a project and realized that the center of handle source tuple was not sufficient for my use case, rather than modify this behavior I could easily adjust the source position if I had access to the handle which the default connection line already finds. this change passes that power onto custom implementations. This allows me to add a `sourceX+(sourceHandle.width/2 - 5)` offset for `Position.Right` source handles. Power than I needed to satisfy application requirements by our design team.