### PR TITLE
Fix when it disappears when connecting an edge to update to a new node

### DIFF
--- a/src/components/Edges/wrapEdge.tsx
+++ b/src/components/Edges/wrapEdge.tsx
@@ -160,7 +160,7 @@ export default (EdgeComponent: ComponentType<EdgeProps>) => {
           _onEdgeUpdate
         );
       },
-      [id, source, target, type, sourceHandleId, targetHandleId, setConnectionNodeId, setPosition, edgeElement]
+      [id, source, target, type, sourceHandleId, targetHandleId, setConnectionNodeId, setPosition, edgeElement, onConnectEdge]
     );
 
     const onEdgeUpdaterSourceMouseDown = useCallback(

--- a/src/container/EdgeRenderer/index.tsx
+++ b/src/container/EdgeRenderer/index.tsx
@@ -72,7 +72,7 @@ const Edge = ({
     (connection: Connection) => {
       props.onEdgeUpdate?.(edge, connection);
     },
-    [edge]
+    [edge, props.onEdgeUpdate]
   );
 
   if (!sourceNode) {


### PR DESCRIPTION
I am using the drag-and-drop function and Edge Update function by applying it to my project, but EdgeUpdate sometimes does not work well.

When I checked, it was not included in the dependencies of the useCallback functions that use onEdgeUpdate.

The onEdgeUpdate function code I used is   
```typescript
const [elements, setElements] = useState<Elements>(initialElements);
const onEdgeUpdate = (oldEdge: Edge, newConnection: Connection) =>
    setElements(updateEdge(oldEdge, newConnection, elements));
```


I think it's better to use the onEdgeUpdate Code from Example, but I hope this code works as well.


Below is a picture of edgeUpdate not working

![Example](https://tusd.tusdemo.net/files/a02cfc1cdc0bb489f779071d078614c4+AHG0Me0UjNJglcbAwio_3xm0B8wud8oJkiAJs_mCr5W1zc4h3_.q33r9p_Dtub.Sqzwp_iMPzSuzHeWiaAekYOjIgblkCxZ5wWt1NhXnJiKXWwcVAFGc4SwkdLQAyoxm)


