### PR TITLE
fix(ControlButton): avoid submit form by click on default ControlButtons

### DIFF
--- a/src/additional-components/Controls/index.tsx
+++ b/src/additional-components/Controls/index.tsx
@@ -26,7 +26,7 @@ export interface ControlProps extends HTMLAttributes<HTMLDivElement> {
 export interface ControlButtonProps extends HTMLAttributes<HTMLButtonElement> {}
 
 export const ControlButton: FC<ControlButtonProps> = ({ children, className, ...rest }) => (
-  <button className={cc(['react-flow__controls-button', className])} {...rest}>
+  <button type="button" className={cc(['react-flow__controls-button', className])} {...rest}>
     {children}
   </button>
 );


### PR DESCRIPTION
Depending on the browser, if we use ReactFlow in a form, a default ControlButton can submit the form : “type” attribute is missing on buttons.