### PR TITLE
Fix Firefox not being transitioned

### DIFF
--- a/src/container/EdgeRenderer/index.tsx
+++ b/src/container/EdgeRenderer/index.tsx
@@ -208,13 +208,13 @@ const EdgeRenderer = (props: EdgeRendererProps) => {
     connectionLineComponent,
     onlyRenderVisibleElements,
   } = props;
-  const transformStyle = `translate(${transform[0]},${transform[1]}) scale(${transform[2]})`;
+  const transformStyle = `translate(${transform[0]}px,${transform[1]}px) scale(${transform[2]})`;
   const renderConnectionLine = connectionNodeId && connectionHandleType;
 
   return (
     <svg width={width} height={height} className="react-flow__edges">
       <MarkerDefinitions color={arrowHeadColor} />
-      <g transform={transformStyle}>
+      <g style={{ transform: transformStyle }}>
         {edges.map((edge: Edge) => (
           <Edge
             key={edge.id}


### PR DESCRIPTION
## Why?

While implementing react-flow in our application I wanted to move the selectedNode to the center of the screen. This makes sure the user can find it even on larger trees. 

To achieve that I added a transition to the two places the translation is applied:

```css
  .react-flow__nodes, .react-flow__edges *: {
      transition: transform 500ms ease-in-out,
    }
```

This works fine in Chrome,. When testing in Firefox the transition did not work however. This seemed to be related to the transfrom being applied as an attribute by react-flow. Attributes are only targeted by the [SVG2](https://www.w3.org/TR/SVG2/) spec which has already been partially implemented in Chrome, but not in Firefox. 

## Fix

To fix this I tested moving the transform into a style tag like it is done for the nodes.
https://github.com/wbkd/react-flow/blob/c5ce586dd9d6a53e600cbff4e9257695fb08e601/src/container/NodeRenderer/index.tsx#L61

With that fix it worked for me in both Chrome and Firefox.