### PR TITLE
Smooth transitions for useZoomPanHelper using built-in d3 functions

### DIFF
--- a/example/src/UseZoomPanHelper/index.tsx
+++ b/example/src/UseZoomPanHelper/index.tsx
@@ -29,7 +29,7 @@ const UseZoomPanHelperFlow = () => {
   const [elements, setElements] = useState<Elements>(initialElements);
   const onElementsRemove = (elementsToRemove: Elements) => setElements((els) => removeElements(elementsToRemove, els));
   const onConnect = (params: Connection | Edge) => setElements((els) => addEdge(params, els));
-  const { project } = useZoomPanHelper();
+  const { project, setCenter, zoomIn, zoomOut } = useZoomPanHelper();
 
   const onPaneClick = useCallback(
     (evt) => {
@@ -48,8 +48,26 @@ const UseZoomPanHelperFlow = () => {
     [project]
   );
 
+  const onElementClick = useCallback(
+    (_, element) => {
+      const { x, y } = element.position;
+      setCenter(x, y, 1);
+    },
+    [setCenter]
+  );
+
   return (
-    <ReactFlow elements={elements} onElementsRemove={onElementsRemove} onConnect={onConnect} onPaneClick={onPaneClick}>
+    <ReactFlow
+      elements={elements}
+      onElementClick={onElementClick}
+      onElementsRemove={onElementsRemove}
+      onConnect={onConnect}
+      onPaneClick={onPaneClick}
+    >
+      <div style={{ position: 'absolute', left: 0, top: 0, zIndex: 100 }}>
+        <button onClick={() => zoomIn(1200)}>zoomIn</button>
+        <button onClick={() => zoomOut(0)}>zoomOut</button>
+      </div>
       <Background />
       <MiniMap />
     </ReactFlow>

--- a/src/hooks/useZoomPanHelper.ts
+++ b/src/hooks/useZoomPanHelper.ts
@@ -20,7 +20,7 @@ const initialZoomPanHelper: ZoomPanHelperFunctions = {
   initialized: false,
 };
 
-const getTransition = (selection: D3Selection<Element, unknown, null, undefined>, duration: number = 300) => {
+const getTransition = (selection: D3Selection<Element, unknown, null, undefined>, duration: number = 0) => {
   return selection.transition().duration(duration);
 };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -262,7 +262,7 @@ export type FlowExportObject<T = any> = {
   zoom: number;
 };
 
-export type FitViewFunc = (fitViewOptions?: FitViewParams) => void;
+export type FitViewFunc = (fitViewOptions?: FitViewParams, duration?: number) => void;
 export type ProjectFunc = (position: XYPosition) => XYPosition;
 export type ToObjectFunc<T = any> = () => FlowExportObject<T>;
 
@@ -372,13 +372,13 @@ export enum PanOnScrollMode {
 }
 
 export interface ZoomPanHelperFunctions {
-  zoomIn: () => void;
-  zoomOut: () => void;
-  zoomTo: (zoomLevel: number) => void;
-  transform: (transform: FlowTransform) => void;
+  zoomIn: (duration?: number) => void;
+  zoomOut: (duration?: number) => void;
+  zoomTo: (zoomLevel: number, duration?: number) => void;
+  transform: (transform: FlowTransform, duration?: number) => void;
   fitView: FitViewFunc;
-  setCenter: (x: number, y: number, zoom?: number) => void;
-  fitBounds: (bounds: Rect, padding?: number) => void;
+  setCenter: (x: number, y: number, zoom?: number, duration?: number) => void;
+  fitBounds: (bounds: Rect, padding?: number, duration?: number) => void;
   project: (position: XYPosition) => XYPosition;
   initialized: boolean;
 }


### PR DESCRIPTION
Smooth transitions were a highly requested feature for react-flow that could be implemented using external libraries like popmotion or tween.js, but this approach is a bit messy since you need to use the reactFlowRef and change its internal viewport directly.

There are some [built-in functions](https://github.com/d3/d3-zoom#zoom_transform) in D3.js that can help with smooth transitions without using any external libraries.  

I've refactored the `useZoomPanHelper` hook functions to use d3 transitions and added the corresponding examples to `/examples/UseZoomPanHelper` directory.

I've also added an optional duration argument to the `zoomIn, zoomOut, zoomTo, transform, fitView, setCenter` and `fitBounds` functions to help the user to change the duration of d3 transitions.

By default, all the functions above have a 300ms transition, but their animations can be disabled by setting their duration to 0.

Here is the UseZoomPanHelper example with `zoomIn` set to `1200ms`, `zoomOut` set to 0 and `setCenter` set to the default value of `300ms`:

https://user-images.githubusercontent.com/17250923/142758194-8c296261-bbe6-45ad-a0dd-52e35fde1e47.mp4


