### PR TITLE
Fix bug in updateNodePosDiff action

### DIFF
--- a/src/store/reducer.ts
+++ b/src/store/reducer.ts
@@ -137,7 +137,7 @@ export default function reactFlowReducer(state = initialState, action: ReactFlow
       const { id, diff, isDragging } = action.payload;
 
       const nextNodes = state.nodes.map((node) => {
-        if (id === node.id || state.selectedElements?.find((sNode) => sNode.id === node.id)) {
+        if (id === node.id || (id == null && state.selectedElements?.find((sNode) => sNode.id === node.id))) {
           const updatedNode = {
             ...node,
             __rf: {


### PR DESCRIPTION
This is the intended logic. Without it triggering this action with a node id will always move selected nodes, which is not desirable if we want to move just an unselected node.

The bug doesn't show up in current examples because at the moment either one selected node is moved or all the selected nodes are moved. TBH this should probably be changed to accept `ids` instead to handle the two cases instead of this tight coupling between the group selection code and this action.