### PR TITLE
add github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,85 @@
+name: '🐛 Bug report'
+description: Create a report to help us improve
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for reporting an issue :pray:.
+
+        This issue tracker is for reporting bugs found in react-flow (https://github.com/wbkd/react-flow)
+        If you have a question about how to achieve something and are struggling, please post a question
+        inside of react-flow's Discussion's tab: https://github.com/wbkd/react-flow/discussions
+        
+        Before submitting a new bug/issue, please check the links below to see if there is a solution or question posted there already:
+         - react-flow's Open Issue's tab: https://github.com/wbkd/react-flow/issues?q=is%3Aissue+sort%3Aupdated-desc+position
+         - react-flow's Closed Issues tab: https://github.com/wbkd/react-flow/issues?q=is%3Aissue+sort%3Aupdated-desc+position+is%3Aclosed
+         - react-flow's Discussion's tab: https://github.com/wbkd/react-flow/discussions
+
+        The more information you fill in, the better the community can help you.
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: Provide a clear and concise description of the challenge you are running into.
+    validations:
+      required: true
+  - type: input
+    id: link
+    attributes:
+      label: Your Example Website or App
+      description: |
+        Which website or app were you using when the bug happened?
+        Note:
+        - Your bug will may get fixed much faster if we can run your code and it doesn't have dependencies other than the `react-flow-renderer` npm package.
+        - To create a shareable code example you can use Stackblitz (https://stackblitz.com/). Please no localhost URLs.
+        - Please read these tips for providing a minimal example: https://stackoverflow.com/help/mcve.
+      placeholder: |
+        e.g. https://stackblitz.com/edit/...... OR Github Repo
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce the Bug or Issue
+      description: Describe the steps we have to take to reproduce the behavior.
+      placeholder: |
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: Provide a clear and concise description of what you expected to happen.
+      placeholder: |
+        As a user, I expected ___ behavior but i am seeing ___
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots_or_videos
+    attributes:
+      label: Screenshots or Videos
+      description: |
+        If applicable, add screenshots or a video to help explain your problem.
+        For more information on the supported file image/file types and the file size limits, please refer
+        to the following link: https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/attaching-files
+      placeholder: |
+        You can drag your video or image files inside of this editor ↓
+  - type: textarea
+    id: platform
+    attributes:
+      label: Platform
+      value: |
+        - OS: [e.g. macOS, Windows, Linux]
+        - Browser: [e.g. Chrome, Safari, Firefox]
+        - Version: [e.g. 91.1]
+    validations:
+      required: true
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 🤔 Feature Requests & Questions 
+    url: https://github.com/wbkd/react-flow/discussions
+    about: Please ask and answer questions here.


### PR DESCRIPTION
## What is the change?
1. Add  `bug_report.md`  to enable Github's new issue template form 
   - https://youtu.be/qQE1BUkf2-s?t=23
2. Add `config.yml` file to direct user's to the right place if they are looking to create an issue or  ask question



## Motivation
- encourage's bug reporter's to put more care into their bug report before submission
- this may help `react-flow`'s maintainer's receive more detailed & higher quality bug report's (_benefits user's / readers as well_)
- prevents bug reporter from submitting a bug IF they do not fill in the required fields specified in the `bug_report.yml` file
- adds helpful tips for user's during the process of creating a bug/issue report


## Demo of Change
- https://github.com/cliffordfajardo/TEST-react-flow-gh-template/issues/new/choose

![CleanShot 2021-12-20 at 11 57 45](https://user-images.githubusercontent.com/6743796/146825241-4cb29b14-e478-417a-82da-bb6fcacea12b.png)

![CleanShot 2021-12-20 at 12 00 06](https://user-images.githubusercontent.com/6743796/146825502-50af8307-ab17-4bc8-809b-a0f8846f7fb0.png)



