### PR TITLE
fix: Fix horizontal scroll issue on windows chrome with panOnScroll true

### DIFF
--- a/src/container/ZoomPane/index.tsx
+++ b/src/container/ZoomPane/index.tsx
@@ -127,8 +127,19 @@ const ZoomPane = ({
             // increase scroll speed in firefox
             // firefox: deltaMode === 1; chrome: deltaMode === 0
             const deltaNormalize = event.deltaMode === 1 ? 20 : 1;
-            const deltaX = panOnScrollMode === PanOnScrollMode.Vertical ? 0 : event.deltaX * deltaNormalize;
-            const deltaY = panOnScrollMode === PanOnScrollMode.Horizontal ? 0 : event.deltaY * deltaNormalize;
+            let deltaX = panOnScrollMode === PanOnScrollMode.Vertical ? 0 : event.deltaX * deltaNormalize;
+            let deltaY = panOnScrollMode === PanOnScrollMode.Horizontal ? 0 : event.deltaY * deltaNormalize;
+
+            /**
+             * In windows chrome the deltaX is not set properly on horizontal scroll with mouse wheel,
+             * Horizontal scroll = shiftKey + mouse wheel
+             * In such case check if shift key is press and only deltaY is changed but not deltaX, the
+             * changes on deltaY belongs to horizontal scroll.
+             */
+            if (panOnScrollMode !== PanOnScrollMode.Vertical && event.shiftKey && !deltaX && deltaY) {
+              deltaX = deltaY;
+              deltaY = 0;
+            }
 
             d3Zoom.translateBy(
               d3Selection,


### PR DESCRIPTION
Windows doesn't update deltaX when horizontally scrolled with shift + mouseWheel instead changes deltaY in such case as well, this PR fixes it by checking if shift is pressed and correct delta is not updated.

Codesandbox link for wheel event:  https://codesandbox.io/s/jolly-bogdan-b5e01?file=/src/index.js
Screenshot:
<img width="960" alt="Screenshot 2021-12-22 090425" src="https://user-images.githubusercontent.com/3096766/147031444-c2e02fbc-d53e-460e-b4e8-70f3b4deb002.png">

