### PR TITLE
Removed wrong type

### DIFF
--- a/src/container/ReactFlow/index.tsx
+++ b/src/container/ReactFlow/index.tsx
@@ -34,7 +34,7 @@ const defaultEdgeTypes = {
 const initSnapGrid: [number, number] = [15, 15];
 const initDefaultPosition: [number, number] = [0, 0];
 
-const ReactFlow: FunctionComponent<ReactFlowProps> = forwardRef<ReactFlowRefType, ReactFlowProps>(
+const ReactFlow = forwardRef<ReactFlowRefType, ReactFlowProps>(
   (
     {
       nodes,


### PR DESCRIPTION
Solves problem: cannot pass ref
Error text:  "Property 'ref' does not exist on type 'IntrinsicAttributes & ReactFlowProps & { children?: ReactNode; }'."
Explanation: implicitly type React.ForwardRefExoticComponent<ReactFlowProps & React.RefAttributes<ReactFlowRefType<ReactFlowRefType>>>