### PR TITLE
refactor connection line

### DIFF
--- a/src/components/ConnectionLine/index.tsx
+++ b/src/components/ConnectionLine/index.tsx
@@ -57,21 +57,21 @@ export default ({
   const toX = (connectionPositionX - transform[0]) / transform[2];
   const toY = (connectionPositionY - transform[1]) / transform[2];
 
-  const fromPostion = fromHandle?.position;
+  const fromPosition = fromHandle?.position;
 
-  let toPostion: Position | undefined;
-  switch (fromPostion) {
+  let toPosition: Position | undefined;
+  switch (fromPosition) {
     case Position.Left:
-      toPostion = Position.Right;
+      toPosition = Position.Right;
       break;
     case Position.Right:
-      toPostion = Position.Left;
+      toPosition = Position.Left;
       break;
     case Position.Top:
-      toPostion = Position.Bottom;
+      toPosition = Position.Bottom;
       break;
     case Position.Bottom:
-      toPostion = Position.Top;
+      toPosition = Position.Top;
       break;
   }
 
@@ -87,20 +87,20 @@ export default ({
       {
         sourceX = fromX;
         sourceY = fromY;
-        sourcePosition = fromPostion;
+        sourcePosition = fromPosition;
         targetX = toX;
         targetY = toY;
-        targetPosition = toPostion;
+        targetPosition = toPosition;
       }
       break;
     case 'target':
       {
         sourceX = toX;
         sourceY = toY;
-        sourcePosition = toPostion;
+        sourcePosition = toPosition;
         targetX = fromX;
         targetY = fromY;
-        targetPosition = fromPostion;
+        targetPosition = fromPosition;
       }
       break;
   }

--- a/src/types/edges.ts
+++ b/src/types/edges.ts
@@ -155,6 +155,9 @@ export type ConnectionLineComponentProps = {
   targetPosition?: Position;
   connectionLineStyle?: CSSProperties;
   connectionLineType: ConnectionLineType;
+  fromNode?: Node;
+  fromHandle?: HandleElement;
+  // backward compatibility, mark as deprecated?
   sourceNode?: Node;
   sourceHandle?: HandleElement;
 };


### PR DESCRIPTION
In that the connection line can be dragged from either the source or target handle, the `source` and `target` naming can be confusing. I suggest using `from` and `to` in a connection line, where the `from` or `to` can either be a `source` or a `target`.

Meanwhile, the `source` and `target` passed to the `CustomConnectionLineComponent` should be consistent with the created edge when the connection is finished.