### PR TITLE
refactor Bezier function

### DIFF
--- a/src/components/ConnectionLine/index.tsx
+++ b/src/components/ConnectionLine/index.tsx
@@ -82,8 +82,6 @@ export default ({
     targetY: number,
     targetPosition: Position | undefined;
 
-  let toCurvature: 'sourceCurvature' | 'targetCurvature';
-
   switch (connectionHandleType) {
     case 'source':
       {
@@ -93,7 +91,6 @@ export default ({
         targetX = toX;
         targetY = toY;
         targetPosition = toPosition;
-        toCurvature = 'targetCurvature';
       }
       break;
     case 'target':
@@ -104,7 +101,6 @@ export default ({
         targetX = fromX;
         targetY = fromY;
         targetPosition = fromPosition;
-        toCurvature = 'sourceCurvature';
       }
       break;
   }
@@ -143,10 +139,8 @@ export default ({
   };
 
   if (connectionLineType === ConnectionLineType.Bezier) {
-    // we don't know the destination position, so we can zero the to curvature
-    dAttr = getBezierPath({ ...pathParams, [toCurvature]: 0 });
-    // or we assume the destination position is opposite to the source position
-    // dAttr = getBezierPath(pathParams);
+    // we assume the destination position is opposite to the source position
+    dAttr = getBezierPath(pathParams);
   } else if (connectionLineType === ConnectionLineType.Step) {
     dAttr = getSmoothStepPath({
       ...pathParams,

--- a/src/components/ConnectionLine/index.tsx
+++ b/src/components/ConnectionLine/index.tsx
@@ -82,6 +82,8 @@ export default ({
     targetY: number,
     targetPosition: Position | undefined;
 
+  let toCurvature: 'sourceCurvature' | 'targetCurvature';
+
   switch (connectionHandleType) {
     case 'source':
       {
@@ -91,6 +93,7 @@ export default ({
         targetX = toX;
         targetY = toY;
         targetPosition = toPosition;
+        toCurvature = 'targetCurvature';
       }
       break;
     case 'target':
@@ -101,6 +104,7 @@ export default ({
         targetX = fromX;
         targetY = fromY;
         targetPosition = fromPosition;
+        toCurvature = 'sourceCurvature';
       }
       break;
   }
@@ -139,9 +143,10 @@ export default ({
   };
 
   if (connectionLineType === ConnectionLineType.Bezier) {
-    // @TODO: we need another getBezier function, that handles a connection line.
-    // Since we don't know the target position, we can't use the default bezier function here.
-    dAttr = getBezierPath({ ...pathParams, curvature: 0 });
+    // we don't know the destination position, so we can zero the to curvature
+    dAttr = getBezierPath({ ...pathParams, [toCurvature]: 0 });
+    // or we assume the destination position is opposite to the source position
+    // dAttr = getBezierPath(pathParams);
   } else if (connectionLineType === ConnectionLineType.Step) {
     dAttr = getSmoothStepPath({
       ...pathParams,

--- a/src/components/ConnectionLine/index.tsx
+++ b/src/components/ConnectionLine/index.tsx
@@ -57,21 +57,21 @@ export default ({
   const toX = (connectionPositionX - transform[0]) / transform[2];
   const toY = (connectionPositionY - transform[1]) / transform[2];
 
-  const fromPostion = fromHandle?.position;
+  const fromPosition = fromHandle?.position;
 
-  let toPostion: Position | undefined;
-  switch (fromPostion) {
+  let toPosition: Position | undefined;
+  switch (fromPosition) {
     case Position.Left:
-      toPostion = Position.Right;
+      toPosition = Position.Right;
       break;
     case Position.Right:
-      toPostion = Position.Left;
+      toPosition = Position.Left;
       break;
     case Position.Top:
-      toPostion = Position.Bottom;
+      toPosition = Position.Bottom;
       break;
     case Position.Bottom:
-      toPostion = Position.Top;
+      toPosition = Position.Top;
       break;
   }
 
@@ -87,20 +87,20 @@ export default ({
       {
         sourceX = fromX;
         sourceY = fromY;
-        sourcePosition = fromPostion;
+        sourcePosition = fromPosition;
         targetX = toX;
         targetY = toY;
-        targetPosition = toPostion;
+        targetPosition = toPosition;
       }
       break;
     case 'target':
       {
         sourceX = toX;
         sourceY = toY;
-        sourcePosition = toPostion;
+        sourcePosition = toPosition;
         targetX = fromX;
         targetY = fromY;
-        targetPosition = fromPostion;
+        targetPosition = fromPosition;
       }
       break;
   }

--- a/src/components/Edges/BezierEdge.tsx
+++ b/src/components/Edges/BezierEdge.tsx
@@ -11,12 +11,78 @@ export interface GetBezierPathParams {
   targetY: number;
   targetPosition?: Position;
   curvature?: number;
+  sourceCurvature?: number;
+  targetCurvature?: number;
   centerX?: number;
   centerY?: number;
 }
 
-// @TODO: refactor getBezierPath function. It's too long and hard to understand.
-// We should reuse the curvature handling for top/bottom and left/right.
+interface GetControlWithCurvatureParams {
+  pos: Position;
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+  cX: number;
+  cY: number;
+  c: number;
+}
+
+function calculateControlOffset(distance: number, curvature: number): number {
+  return curvature * 25 * Math.sqrt(distance);
+}
+
+function getControlWithCurvature({ pos, x1, y1, x2, y2, cX, cY, c }: GetControlWithCurvatureParams): [number, number] {
+  let ctX: number, ctY: number;
+  switch (pos) {
+    case Position.Left:
+      {
+        const d = x2 - x1;
+        ctY = y1;
+        if (d <= 0) {
+          ctX = cX;
+        } else {
+          ctX = x1 - calculateControlOffset(d, c);
+        }
+      }
+      break;
+    case Position.Right:
+      {
+        const d = x1 - x2;
+        ctY = y1;
+        if (d <= 0) {
+          ctX = cX;
+        } else {
+          ctX = x1 + calculateControlOffset(d, c);
+        }
+      }
+      break;
+    case Position.Top:
+      {
+        const d = y2 - y1;
+        ctX = x1;
+        if (d <= 0) {
+          ctY = cY;
+        } else {
+          ctY = y1 - calculateControlOffset(d, c);
+        }
+      }
+      break;
+    case Position.Bottom:
+      {
+        const d = y1 - y2;
+        ctX = x1;
+        if (d <= 0) {
+          ctY = cY;
+        } else {
+          ctY = y1 + calculateControlOffset(d, c);
+        }
+      }
+      break;
+  }
+  return [ctX, ctY];
+}
+
 export function getBezierPath({
   sourceX,
   sourceY,
@@ -25,78 +91,35 @@ export function getBezierPath({
   targetY,
   targetPosition = Position.Top,
   curvature = 0.25,
+  sourceCurvature = curvature,
+  targetCurvature = curvature,
   centerX,
   centerY,
 }: GetBezierPathParams): string {
-  const leftAndRight = [Position.Left, Position.Right];
-  const hasCurvature = curvature > 0;
   const [_centerX, _centerY] = getCenter({ sourceX, sourceY, targetX, targetY });
-
-  if (leftAndRight.includes(sourcePosition) && leftAndRight.includes(targetPosition)) {
-    const cX = typeof centerX !== 'undefined' ? centerX : _centerX;
-    const distanceX = targetX - sourceX;
-    const absDistanceX = Math.abs(distanceX);
-    const amtX = (Math.sqrt(absDistanceX) / 2) * (50 * curvature);
-
-    let hx1 = cX;
-    let hx2 = cX;
-
-    if (hasCurvature) {
-      const sourceAndTargetRight = sourcePosition === Position.Right && targetPosition === Position.Right;
-      const sourceAndTargetLeft = sourcePosition === Position.Left && targetPosition === Position.Left;
-
-      hx1 = sourceX + amtX;
-      hx2 = targetX - amtX;
-
-      if (sourceAndTargetLeft) {
-        hx1 = sourceX - amtX;
-      } else if (sourceAndTargetRight) {
-        hx2 = targetX + amtX;
-      } else if (sourcePosition === Position.Left && targetX <= sourceX) {
-        hx1 = cX;
-        hx2 = cX;
-      } else if (sourcePosition === Position.Left && targetX > sourceX) {
-        hx1 = sourceX - amtX;
-        hx2 = targetX + amtX;
-      }
-    }
-
-    return `M${sourceX},${sourceY} C${hx1},${sourceY} ${hx2},${targetY}, ${targetX},${targetY}`;
-  } else if (leftAndRight.includes(targetPosition)) {
-    return `M${sourceX},${sourceY} Q${sourceX},${targetY} ${targetX},${targetY}`;
-  } else if (leftAndRight.includes(sourcePosition)) {
-    return `M${sourceX},${sourceY} Q${targetX},${sourceY} ${targetX},${targetY}`;
-  }
-
-  const cY = typeof centerY !== 'undefined' ? centerY : _centerY;
-  const distanceY = targetY - sourceY;
-  const absDistanceY = Math.abs(distanceY);
-  const amtY = (Math.sqrt(absDistanceY) / 2) * (50 * curvature);
-
-  let hy1 = cY;
-  let hy2 = cY;
-
-  if (hasCurvature) {
-    hy1 = sourceY + amtY;
-    hy2 = targetY - amtY;
-
-    const sourceAndTargetTop = sourcePosition === Position.Top && targetPosition === Position.Top;
-    const sourceAndTargetBottom = sourcePosition === Position.Bottom && targetPosition === Position.Bottom;
-
-    if (sourceAndTargetTop) {
-      hy1 = targetY - amtY;
-    } else if (sourceAndTargetBottom) {
-      hy2 = targetY + amtY;
-    } else if (sourcePosition === Position.Top && targetY <= sourceY) {
-      hy1 = cY;
-      hy2 = cY;
-    } else if (sourcePosition === Position.Top && targetY > sourceY) {
-      hy1 = sourceY - amtY;
-      hy2 = targetY + amtY;
-    }
-  }
-
-  return `M${sourceX},${sourceY} C${sourceX},${hy1} ${targetX},${hy2} ${targetX},${targetY}`;
+  centerX = centerX ?? _centerX;
+  centerY = centerY ?? _centerY;
+  const [sourceControlX, sourceControlY] = getControlWithCurvature({
+    pos: sourcePosition,
+    x1: sourceX,
+    y1: sourceY,
+    x2: targetX,
+    y2: targetY,
+    cX: centerX,
+    cY: centerY,
+    c: sourceCurvature,
+  });
+  const [targetControlX, targetControlY] = getControlWithCurvature({
+    pos: targetPosition,
+    x1: targetX,
+    y1: targetY,
+    x2: sourceX,
+    y2: sourceY,
+    cX: centerX,
+    cY: centerY,
+    c: targetCurvature,
+  });
+  return `M${sourceX},${sourceY} C${sourceControlX},${sourceControlY} ${targetControlX},${targetControlY} ${targetX},${targetY}`;
 }
 
 export default memo(

--- a/src/components/Edges/BezierEdge.tsx
+++ b/src/components/Edges/BezierEdge.tsx
@@ -11,8 +11,6 @@ export interface GetBezierPathParams {
   targetY: number;
   targetPosition?: Position;
   curvature?: number;
-  sourceCurvature?: number;
-  targetCurvature?: number;
   centerX?: number;
   centerY?: number;
 }
@@ -91,8 +89,6 @@ export function getBezierPath({
   targetY,
   targetPosition = Position.Top,
   curvature = 0.25,
-  sourceCurvature = curvature,
-  targetCurvature = curvature,
   centerX,
   centerY,
 }: GetBezierPathParams): string {
@@ -107,7 +103,7 @@ export function getBezierPath({
     y2: targetY,
     cX: centerX,
     cY: centerY,
-    c: sourceCurvature,
+    c: curvature,
   });
   const [targetControlX, targetControlY] = getControlWithCurvature({
     pos: targetPosition,
@@ -117,7 +113,7 @@ export function getBezierPath({
     y2: sourceY,
     cX: centerX,
     cY: centerY,
-    c: targetCurvature,
+    c: curvature,
   });
   return `M${sourceX},${sourceY} C${sourceControlX},${sourceControlY} ${targetControlX},${targetControlY} ${targetX},${targetY}`;
 }

--- a/src/components/Edges/BezierEdge.tsx
+++ b/src/components/Edges/BezierEdge.tsx
@@ -117,7 +117,7 @@ export function getBezierCenter({
     y2: sourceY,
     c: curvature,
   });
-  // quadratic bezier t=0.5 mid point, not the actual mid point, but easy to calculate
+  // cubic bezier t=0.5 mid point, not the actual mid point, but easy to calculate
   // https://stackoverflow.com/questions/67516101/how-to-find-distance-mid-point-of-bezier-curve
   const centerX = sourceX * 0.125 + sourceControlX * 0.375 + targetControlX * 0.375 + targetX * 0.125;
   const centerY = sourceY * 0.125 + sourceControlY * 0.375 + targetControlY * 0.375 + targetY * 0.125;

--- a/src/components/Edges/BezierEdge.tsx
+++ b/src/components/Edges/BezierEdge.tsx
@@ -10,8 +10,6 @@ export interface GetBezierPathParams {
   targetY: number;
   targetPosition?: Position;
   curvature?: number;
-  centerX?: number;
-  centerY?: number;
 }
 
 interface GetControlWithCurvatureParams {

--- a/src/components/Edges/BezierEdge.tsx
+++ b/src/components/Edges/BezierEdge.tsx
@@ -21,60 +21,42 @@ interface GetControlWithCurvatureParams {
   y1: number;
   x2: number;
   y2: number;
-  cX: number;
-  cY: number;
   c: number;
 }
 
 function calculateControlOffset(distance: number, curvature: number): number {
-  return curvature * 25 * Math.sqrt(distance);
+  if (distance >= 0) {
+    return 0.5 * distance;
+  } else {
+    return curvature * 25 * Math.sqrt(-distance);
+  }
 }
 
-function getControlWithCurvature({ pos, x1, y1, x2, y2, cX, cY, c }: GetControlWithCurvatureParams): [number, number] {
+function getControlWithCurvature({ pos, x1, y1, x2, y2, c }: GetControlWithCurvatureParams): [number, number] {
   let ctX: number, ctY: number;
   switch (pos) {
     case Position.Left:
       {
-        const d = x2 - x1;
+        ctX = x1 - calculateControlOffset(x1 - x2, c);
         ctY = y1;
-        if (d <= 0) {
-          ctX = cX;
-        } else {
-          ctX = x1 - calculateControlOffset(d, c);
-        }
       }
       break;
     case Position.Right:
       {
-        const d = x1 - x2;
+        ctX = x1 + calculateControlOffset(x2 - x1, c);
         ctY = y1;
-        if (d <= 0) {
-          ctX = cX;
-        } else {
-          ctX = x1 + calculateControlOffset(d, c);
-        }
       }
       break;
     case Position.Top:
       {
-        const d = y2 - y1;
         ctX = x1;
-        if (d <= 0) {
-          ctY = cY;
-        } else {
-          ctY = y1 - calculateControlOffset(d, c);
-        }
+        ctY = y1 - calculateControlOffset(y1 - y2, c);
       }
       break;
     case Position.Bottom:
       {
-        const d = y1 - y2;
         ctX = x1;
-        if (d <= 0) {
-          ctY = cY;
-        } else {
-          ctY = y1 + calculateControlOffset(d, c);
-        }
+        ctY = y1 + calculateControlOffset(y2 - y1, c);
       }
       break;
   }
@@ -89,20 +71,13 @@ export function getBezierPath({
   targetY,
   targetPosition = Position.Top,
   curvature = 0.25,
-  centerX,
-  centerY,
 }: GetBezierPathParams): string {
-  const [_centerX, _centerY] = getCenter({ sourceX, sourceY, targetX, targetY });
-  centerX = centerX ?? _centerX;
-  centerY = centerY ?? _centerY;
   const [sourceControlX, sourceControlY] = getControlWithCurvature({
     pos: sourcePosition,
     x1: sourceX,
     y1: sourceY,
     x2: targetX,
     y2: targetY,
-    cX: centerX,
-    cY: centerY,
     c: curvature,
   });
   const [targetControlX, targetControlY] = getControlWithCurvature({
@@ -111,8 +86,6 @@ export function getBezierPath({
     y1: targetY,
     x2: sourceX,
     y2: sourceY,
-    cX: centerX,
-    cY: centerY,
     c: curvature,
   });
   return `M${sourceX},${sourceY} C${sourceControlX},${sourceControlY} ${targetControlX},${targetControlY} ${targetX},${targetY}`;

--- a/src/components/Edges/BezierEdge.tsx
+++ b/src/components/Edges/BezierEdge.tsx
@@ -1,7 +1,6 @@
 import React, { memo } from 'react';
 import { EdgeProps, Position } from '../../types';
 import BaseEdge from './BaseEdge';
-import { getCenter } from './utils';
 
 export interface GetBezierPathParams {
   sourceX: number;
@@ -91,6 +90,44 @@ export function getBezierPath({
   return `M${sourceX},${sourceY} C${sourceControlX},${sourceControlY} ${targetControlX},${targetControlY} ${targetX},${targetY}`;
 }
 
+// @TODO: this function will recalculate the control points
+// one option is to let getXXXPath() return center points
+// but will introduce breaking changes
+// the getCenter() of other types of edges might need to change, too
+export function getBezierCenter({
+  sourceX,
+  sourceY,
+  sourcePosition = Position.Bottom,
+  targetX,
+  targetY,
+  targetPosition = Position.Top,
+  curvature = 0.25,
+}: GetBezierPathParams): [number, number, number, number] {
+  const [sourceControlX, sourceControlY] = getControlWithCurvature({
+    pos: sourcePosition,
+    x1: sourceX,
+    y1: sourceY,
+    x2: targetX,
+    y2: targetY,
+    c: curvature,
+  });
+  const [targetControlX, targetControlY] = getControlWithCurvature({
+    pos: targetPosition,
+    x1: targetX,
+    y1: targetY,
+    x2: sourceX,
+    y2: sourceY,
+    c: curvature,
+  });
+  // quadratic bezier t=0.5 mid point, not the actual mid point, but easy to calculate
+  // https://stackoverflow.com/questions/67516101/how-to-find-distance-mid-point-of-bezier-curve
+  const centerX = sourceX * 0.125 + sourceControlX * 0.375 + targetControlX * 0.375 + targetX * 0.125;
+  const centerY = sourceY * 0.125 + sourceControlY * 0.375 + targetControlY * 0.375 + targetY * 0.125;
+  const xOffset = Math.abs(centerX - sourceX);
+  const yOffset = Math.abs(centerY - sourceY);
+  return [centerX, centerY, xOffset, yOffset];
+}
+
 export default memo(
   ({
     sourceX,
@@ -110,8 +147,7 @@ export default memo(
     markerStart,
     curvature,
   }: EdgeProps) => {
-    const [centerX, centerY] = getCenter({ sourceX, sourceY, targetX, targetY, sourcePosition, targetPosition });
-    const path = getBezierPath({
+    const params = {
       sourceX,
       sourceY,
       sourcePosition,
@@ -119,7 +155,9 @@ export default memo(
       targetY,
       targetPosition,
       curvature,
-    });
+    };
+    const path = getBezierPath(params);
+    const [centerX, centerY] = getBezierCenter(params);
 
     return (
       <BaseEdge

--- a/src/components/Edges/SimpleBezierEdge.tsx
+++ b/src/components/Edges/SimpleBezierEdge.tsx
@@ -91,7 +91,7 @@ export function getSimpleBezierCenter({
     x2: sourceX,
     y2: sourceY,
   });
-  // quadratic bezier t=0.5 mid point, not the actual mid point, but easy to calculate
+  // cubic bezier t=0.5 mid point, not the actual mid point, but easy to calculate
   // https://stackoverflow.com/questions/67516101/how-to-find-distance-mid-point-of-bezier-curve
   const centerX = sourceX * 0.125 + sourceControlX * 0.375 + targetControlX * 0.375 + targetX * 0.125;
   const centerY = sourceY * 0.125 + sourceControlY * 0.375 + targetControlY * 0.375 + targetY * 0.125;

--- a/src/components/Edges/SimpleBezierEdge.tsx
+++ b/src/components/Edges/SimpleBezierEdge.tsx
@@ -1,12 +1,121 @@
 import React, { memo } from 'react';
+import { EdgeProps, Position } from '../../types';
+import BaseEdge from './BaseEdge';
+import { getCenter } from './utils';
 
-import BezierEdge, { getBezierPath, GetBezierPathParams } from './BezierEdge';
-import { EdgeProps } from '../../types';
-
-export function getSimpleBezierPath(props: GetBezierPathParams): string {
-  return getBezierPath({ ...props, curvature: 0 });
+export interface GetSimpleBezierPathParams {
+  sourceX: number;
+  sourceY: number;
+  sourcePosition?: Position;
+  targetX: number;
+  targetY: number;
+  targetPosition?: Position;
+  centerX?: number;
+  centerY?: number;
 }
 
-export default memo((props: EdgeProps) => {
-  return <BezierEdge {...props} curvature={0} />;
-});
+interface GetControlParams {
+  pos: Position;
+  x: number;
+  y: number;
+  cX: number;
+  cY: number;
+}
+
+function getControl({ pos, x, y, cX, cY }: GetControlParams): [number, number] {
+  let ctX: number, ctY: number;
+  switch (pos) {
+    case Position.Left:
+    case Position.Right:
+      {
+        ctX = cX;
+        ctY = y;
+      }
+      break;
+    case Position.Top:
+    case Position.Bottom:
+      {
+        ctX = x;
+        ctY = cY;
+      }
+      break;
+  }
+  return [ctX, ctY];
+}
+
+export function getSimpleBezierPath({
+  sourceX,
+  sourceY,
+  sourcePosition = Position.Bottom,
+  targetX,
+  targetY,
+  targetPosition = Position.Top,
+  centerX,
+  centerY,
+}: GetSimpleBezierPathParams): string {
+  const [_centerX, _centerY] = getCenter({ sourceX, sourceY, targetX, targetY });
+  centerX = centerX ?? _centerX;
+  centerY = centerY ?? _centerY;
+  const [sourceControlX, sourceControlY] = getControl({
+    pos: sourcePosition,
+    x: sourceX,
+    y: sourceY,
+    cX: centerX,
+    cY: centerY,
+  });
+  const [targetControlX, targetControlY] = getControl({
+    pos: targetPosition,
+    x: targetX,
+    y: targetY,
+    cX: centerX,
+    cY: centerY,
+  });
+  return `M${sourceX},${sourceY} C${sourceControlX},${sourceControlY} ${targetControlX},${targetControlY} ${targetX},${targetY}`;
+}
+
+export default memo(
+  ({
+    sourceX,
+    sourceY,
+    targetX,
+    targetY,
+    sourcePosition = Position.Bottom,
+    targetPosition = Position.Top,
+    label,
+    labelStyle,
+    labelShowBg,
+    labelBgStyle,
+    labelBgPadding,
+    labelBgBorderRadius,
+    style,
+    markerEnd,
+    markerStart,
+  }: EdgeProps) => {
+    const [centerX, centerY] = getCenter({ sourceX, sourceY, targetX, targetY, sourcePosition, targetPosition });
+    const path = getSimpleBezierPath({
+      sourceX,
+      sourceY,
+      sourcePosition,
+      targetX,
+      targetY,
+      targetPosition,
+    });
+
+    return (
+      <BaseEdge
+        path={path}
+        centerX={centerX}
+        centerY={centerY}
+        label={label}
+        labelStyle={labelStyle}
+        labelShowBg={labelShowBg}
+        labelBgStyle={labelBgStyle}
+        labelBgPadding={labelBgPadding}
+        labelBgBorderRadius={labelBgBorderRadius}
+        style={style}
+        markerEnd={markerEnd}
+        markerStart={markerStart}
+      />
+    );
+  }
+);

--- a/src/types/edges.ts
+++ b/src/types/edges.ts
@@ -155,6 +155,9 @@ export type ConnectionLineComponentProps = {
   targetPosition?: Position;
   connectionLineStyle?: CSSProperties;
   connectionLineType: ConnectionLineType;
+  fromNode?: Node;
+  fromHandle?: HandleElement;
+  // backward compatibility, mark as deprecated?
   sourceNode?: Node;
   sourceHandle?: HandleElement;
 };


### PR DESCRIPTION
- I rewrote the Bezier function to make it more clear and different positions are handled uniformly.
- ~~I added the `sourceCurvature` and `targetCurvature` to address the connection line problem, where the destination is not known in advance when connecting.~~ Upon reflection I removed these two parameter: https://github.com/wbkd/react-flow/pull/1984#issuecomment-1072294366.
- I splitted `getBezierPath` and `getSimpleBezierPath` into two functions. As I understand, simple Bezier and a Bezier with curvature equals to `0` are two different shapes. Simple Bezier actually has control points at the center of the edge, while `curvature = 0` means the control points coincide with the start or end point. In the existing code, setting `curvature` to `0` and `0.000001` will create two totally different shapes.

This demo below was when I added `sourceCurvature` and `targetCurvature`, and wanted to only specify the curvature at the start point and use`0` as the curvature at the end point for the connection line. Later I decided to drop this design.

https://user-images.githubusercontent.com/10386119/158987740-9e1e56a2-1038-4221-8c1b-41fca88b2547.mp4