### PR TITLE
refactor <NodeWrapper/> mouse event handlers

### DIFF
--- a/src/components/Nodes/wrapNode.tsx
+++ b/src/components/Nodes/wrapNode.tsx
@@ -179,7 +179,7 @@ export default (NodeComponent: ComponentType<NodeProps>) => {
     );
 
     // on drag stop handler, will get triggered by click
-    // but click is already handled in onClickNodeHandler
+    // but click is already handled in onNodeClickHandler
     // so we don't need to handle it in this handler
     const onDragStop = useCallback(
       (event: DraggableEvent) => {

--- a/src/components/Nodes/wrapNode.tsx
+++ b/src/components/Nodes/wrapNode.tsx
@@ -101,7 +101,6 @@ export default (NodeComponent: ComponentType<NodeProps>) => {
     // because select and drag are two different actions
     const onMouseDownHandler = useCallback(
       (event: globalThis.MouseEvent) => {
-        console.log(event.target);
         // handle selection related behaviors
         if (isSelectable && !(event.currentTarget as Element).classList.contains(noDragClassName)) {
           // deactive drag selection mode (drag selection cannot start from a node)

--- a/src/components/Nodes/wrapNode.tsx
+++ b/src/components/Nodes/wrapNode.tsx
@@ -130,7 +130,7 @@ export default (NodeComponent: ComponentType<NodeProps>) => {
     );
 
     // on click handler
-    const onClickNodeHandler = useCallback(
+    const onNodeClickHandler = useCallback(
       (event: MouseEvent) => {
         // if there's a corresponding onClick handler, execute it
         if (onClick) {
@@ -271,7 +271,7 @@ export default (NodeComponent: ComponentType<NodeProps>) => {
         onDrag={onDrag}
         onStop={onDragStop}
         // we cannot set onMouseDown on the <div>
-        // because it will be overriden by what is defined here
+        // because it will be overridden by what is defined here
         onMouseDown={onMouseDownHandler}
         scale={scale}
         disabled={!isDraggable}
@@ -289,7 +289,7 @@ export default (NodeComponent: ComponentType<NodeProps>) => {
           onMouseMove={onMouseMoveHandler}
           onMouseLeave={onMouseLeaveHandler}
           onContextMenu={onContextMenuHandler}
-          onClick={onClickNodeHandler}
+          onClick={onNodeClickHandler}
           onDoubleClick={onNodeDoubleClickHandler}
           data-id={id}
         >


### PR DESCRIPTION
- Separated concerns of multiple mouse events: `onMouseDown`(for selection), `onClick`, `onDragStart`, `onDrag`, `onDragStop` in `<NodeWrapper/>`. Remove some duplicated "if condition" and "state management" code that may cause potential bugs (like this one: https://github.com/wbkd/react-flow/issues/1985).
- Added some comments, I hope that's acceptable.
- ⚠️ Breaking change: specifying a selector to be used as the drag handle will not prevent the whole node from being selected. For compatiblity reasons, you can use `nodrag` classname to explictly set some elements in the node nonselectable. But there're two problems here:
  1. This classname api cannot handle dynamically added elements with `nodrag` classnames, I'd prefer a hook api.
  2. If we use this classname api and somehow fix the problem in 1, the classname should still be `noselect` instead of `nodrag`. I don't think it's a good idea to not distinguish these two actions.