### PR TITLE
fixed useKeyPress issues, easily interfered by (default) hotkey

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "d3-selection": "^3.0.0",
         "d3-zoom": "^3.0.0",
         "react-draggable": "^4.4.4",
+        "react-hotkeys-hook": "^3.4.4",
         "zustand": "^3.7.1"
       },
       "devDependencies": {
@@ -5456,6 +5457,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/hotkeys-js": {
+      "version": "3.8.7",
+      "resolved": "https://registry.npmjs.org/hotkeys-js/-/hotkeys-js-3.8.7.tgz",
+      "integrity": "sha512-ckAx3EkUr5XjDwjEHDorHxRO2Kb7z6Z2Sxul4MbBkN8Nho7XDslQsgMJT+CiJ5Z4TgRxxvKHEpuLE3imzqy4Lg=="
+    },
     "node_modules/http-cache-semantics": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
@@ -8431,6 +8437,18 @@
       "peerDependencies": {
         "react": ">= 16.3.0",
         "react-dom": ">= 16.3.0"
+      }
+    },
+    "node_modules/react-hotkeys-hook": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/react-hotkeys-hook/-/react-hotkeys-hook-3.4.4.tgz",
+      "integrity": "sha512-vaORq07rWgmuF3owWRhgFV/3VL8/l2q9lz0WyVEddJnWTtKW+AOgU5YgYKuwN6h6h7bCcLG3MFsJIjCrM/5DvQ==",
+      "dependencies": {
+        "hotkeys-js": "3.8.7"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.1",
+        "react-dom": ">=16.8.1"
       }
     },
     "node_modules/react-is": {
@@ -14372,6 +14390,11 @@
       "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
       "dev": true
     },
+    "hotkeys-js": {
+      "version": "3.8.7",
+      "resolved": "https://registry.npmjs.org/hotkeys-js/-/hotkeys-js-3.8.7.tgz",
+      "integrity": "sha512-ckAx3EkUr5XjDwjEHDorHxRO2Kb7z6Z2Sxul4MbBkN8Nho7XDslQsgMJT+CiJ5Z4TgRxxvKHEpuLE3imzqy4Lg=="
+    },
     "http-cache-semantics": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
@@ -16513,6 +16536,14 @@
       "requires": {
         "clsx": "^1.1.1",
         "prop-types": "^15.6.0"
+      }
+    },
+    "react-hotkeys-hook": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/react-hotkeys-hook/-/react-hotkeys-hook-3.4.4.tgz",
+      "integrity": "sha512-vaORq07rWgmuF3owWRhgFV/3VL8/l2q9lz0WyVEddJnWTtKW+AOgU5YgYKuwN6h6h7bCcLG3MFsJIjCrM/5DvQ==",
+      "requires": {
+        "hotkeys-js": "3.8.7"
       }
     },
     "react-is": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "d3-selection": "^3.0.0",
     "d3-zoom": "^3.0.0",
     "react-draggable": "^4.4.4",
+    "react-hotkeys-hook": "^3.4.4",
     "zustand": "^3.7.1"
   },
   "devDependencies": {

--- a/src/hooks/useKeyPress.ts
+++ b/src/hooks/useKeyPress.ts
@@ -1,113 +1,28 @@
-import { useState, useEffect, useRef, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import { KeyCode } from '../types';
+import { useHotkeys } from "react-hotkeys-hook";
 
-type Keys = Array<string>;
-type PressedKeys = Set<string>;
-type KeyOrCode = 'key' | 'code';
-export interface UseKeyPressOptions {
-  target: Window | Document | HTMLElement | ShadowRoot | null;
-}
-
-const doc = typeof document !== 'undefined' ? document : null;
-
-// the keycode can be a string 'a' or an array of strings ['a', 'a+d']
-// a string means a single key 'a' or a combination when '+' is used 'a+d'
-// an array means different possibilites. Explainer: ['a', 'd+s'] here the
-// user can use the single key 'a' or the combination 'd' + 's'
-export default (keyCode: KeyCode | null = null, options: UseKeyPressOptions = { target: doc }): boolean => {
+// the keycode can be a string 'a' or an array of strings ['a', 'd']
+// a string means a single key 'a' or 'Meta'
+// an array means different possibilities. Explainer: ['a', 'Shift'] here the
+// user can use the single key 'a' or the 'Shift' key or both to set the state to true.
+// If any of te pressed keys are released, te stat will return to false again, even if on of the keys is still held.
+// for combination hotkeys, like 'ctrl+a' use useHotkeys with a callback instead.
+export default (keyCode: KeyCode | null = null): boolean => {
   const [keyPressed, setKeyPressed] = useState(false);
+  const keyCodes = useMemo(() => Array.isArray(keyCode) ? keyCode : [keyCode || ''], [keyCode]);
+  const singles = useMemo(() => keyCodes.filter(k => !k.includes('+') || k === '+'), [keyCodes]);
 
-  // we need to remember the pressed keys in order to support combinations
-  const pressedKeys = useRef<PressedKeys>(new Set([]));
-
-  // keyCodes = array with single keys [['a']] or key combinations [['a', 's']]
-  // keysToWatch = array with all keys flattened ['a', 'd', 'ShiftLeft']
-  // used to check if we store event.code or event.key. When the code is in the list of keysToWatch
-  // we use the code otherwise the key. Explainer: When you press the left "command" key, the code is "MetaLeft"
-  // and the key is "Meta". We want users to be able to pass keys and codes so we assume that the key is meant when
-  // we can't find it in the list of keysToWatch.
-  const [keyCodes, keysToWatch] = useMemo<[Array<Keys>, Keys]>(() => {
-    if (keyCode !== null) {
-      const keyCodeArr = Array.isArray(keyCode) ? keyCode : [keyCode];
-      const keys = keyCodeArr.filter((kc) => typeof kc === 'string').map((kc) => kc.split('+'));
-      const keysFlat = keys.reduce((res: Keys, item) => res.concat(...item), []);
-
-      return [keys, keysFlat];
+  const handleSingleKeyEvent = useCallback((e: KeyboardEvent, isDown: boolean) => {
+    if (singles.includes(e.code) || singles.includes(e.key)) {
+      e.preventDefault();
+      setKeyPressed(isDown);
     }
+  },[singles, setKeyPressed]);
 
-    return [[], []];
-  }, [keyCode]);
-
-  useEffect(() => {
-    if (keyCode !== null) {
-      const downHandler = (event: KeyboardEvent) => {
-        const keyOrCode = useKeyOrCode(event.code, keysToWatch);
-        pressedKeys.current.add(event[keyOrCode]);
-
-        if (isMatchingKey(event, keyCodes, pressedKeys.current)) {
-          event.preventDefault();
-          setKeyPressed(true);
-        }
-      };
-
-      const upHandler = (event: KeyboardEvent) => {
-        const keyOrCode = useKeyOrCode(event.code, keysToWatch);
-
-        if (isMatchingKey(event, keyCodes, pressedKeys.current)) {
-          setKeyPressed(false);
-        }
-
-        pressedKeys.current.delete(event[keyOrCode]);
-      };
-
-      const resetHandler = () => {
-        pressedKeys.current.clear();
-        setKeyPressed(false);
-      };
-
-      options?.target?.addEventListener('keydown', downHandler as EventListenerOrEventListenerObject);
-      options?.target?.addEventListener('keyup', upHandler as EventListenerOrEventListenerObject);
-      window.addEventListener('blur', resetHandler);
-
-      return () => {
-        pressedKeys.current.clear();
-
-        options?.target?.removeEventListener('keydown', downHandler as EventListenerOrEventListenerObject);
-        options?.target?.removeEventListener('keyup', upHandler as EventListenerOrEventListenerObject);
-        window.removeEventListener('blur', resetHandler);
-      };
-    }
-  }, [keyCode, setKeyPressed]);
+  useHotkeys('*', (e) => handleSingleKeyEvent(e, true), {keydown: true});
+  useHotkeys('*', (e) => handleSingleKeyEvent(e, false), {keyup: true});
 
   return keyPressed;
 };
-
-// utils
-
-function isMatchingKey(event: KeyboardEvent, keyCodes: Array<Keys>, pressedKeys: PressedKeys): boolean {
-  if (isInputDOMNode(event)) {
-    return false;
-  }
-
-  return (
-    keyCodes
-      // we only want to compare same sizes of keyCode definitions
-      // and pressed keys. When the user specified 'Meta' as a key somewhere
-      // this would also be truthy without this filter when user presses 'Meta' + 'r'
-      .filter((keys) => keys.length === pressedKeys.size)
-      // since we want to support multiple possibilities only one of the
-      // combinations need to be part of the pressed keys
-      .some((keys) => keys.every((k) => pressedKeys.has(k)))
-  );
-}
-
-function useKeyOrCode(eventCode: string, keysToWatch: KeyCode): KeyOrCode {
-  return keysToWatch.includes(eventCode) ? 'code' : 'key';
-}
-
-function isInputDOMNode(e: KeyboardEvent): boolean {
-  const target = e?.target as HTMLElement;
-
-  return ['INPUT', 'SELECT', 'TEXTAREA'].includes(target?.nodeName) || target?.hasAttribute('contenteditable');
-}


### PR DESCRIPTION
useKeyPress could get in a constant pressed (true) state when a key combo using one of the keys would be used. This resulted in the Meta or Control being "stuck", whenever trying to use very common hotkeys. It also made any usefull hotkey implementation in an app impossible.
 
[https://github.com/wbkd/react-flow/issues/2022](See bug report about multiselection getting stuck.)

The new implementation won't support combo keys itself, but they didn't work properly before anyway. Using useHotkeys for combo's is much better and well proven. A very light dependency.