### PR TITLE
Ability to change default edge zIndex

### DIFF
--- a/src/components/StoreUpdater/index.tsx
+++ b/src/components/StoreUpdater/index.tsx
@@ -49,6 +49,7 @@ interface StoreUpdaterProps {
   fitViewOptions?: FitViewOptions;
   onNodesDelete?: OnNodesDelete;
   onEdgesDelete?: OnEdgesDelete;
+  defaultZLevel?: number,
 }
 
 const selector = (s: ReactFlowState) => ({
@@ -60,6 +61,7 @@ const selector = (s: ReactFlowState) => ({
   setTranslateExtent: s.setTranslateExtent,
   setNodeExtent: s.setNodeExtent,
   reset: s.reset,
+  defaultZLevel: s.defaultZLevel,
 });
 
 function useStoreUpdater<T>(value: T | undefined, setStoreState: (param: T) => void) {
@@ -106,6 +108,7 @@ const StoreUpdater = ({
   fitViewOptions,
   onNodesDelete,
   onEdgesDelete,
+  defaultZLevel,
 }: StoreUpdaterProps) => {
   const {
     setNodes,
@@ -116,11 +119,13 @@ const StoreUpdater = ({
     setTranslateExtent,
     setNodeExtent,
     reset,
+    setDefaultZLevel,
   } = useStore(selector, shallow);
   const store = useStoreApi();
 
   useEffect(() => {
     setDefaultNodesAndEdges(defaultNodes, defaultEdges);
+    setDefaultZLevel(defaultZLevel);
 
     return () => {
       reset();

--- a/src/container/EdgeRenderer/index.tsx
+++ b/src/container/EdgeRenderer/index.tsx
@@ -48,6 +48,7 @@ const selector = (s: ReactFlowState) => ({
   height: s.height,
   connectionMode: s.connectionMode,
   nodeInternals: s.nodeInternals,
+  defaultZLevel: s.defaultZLevel,
 });
 
 const EdgeRenderer = (props: EdgeRendererProps) => {
@@ -62,8 +63,9 @@ const EdgeRenderer = (props: EdgeRendererProps) => {
     height,
     connectionMode,
     nodeInternals,
+    defaultZLevel,
   } = useStore(selector, shallow);
-  const edgeTree = useVisibleEdges(props.onlyRenderVisibleElements, nodeInternals);
+  const edgeTree = useVisibleEdges(props.onlyRenderVisibleElements, nodeInternals, defaultZLevel || 0);
 
   if (!width) {
     return null;

--- a/src/container/ReactFlow/index.tsx
+++ b/src/container/ReactFlow/index.tsx
@@ -135,6 +135,7 @@ const ReactFlow = forwardRef<ReactFlowRefType, ReactFlowProps>(
       attributionPosition,
       proOptions,
       defaultEdgeOptions,
+      defaultZLevel = 0,
       ...rest
     },
     ref
@@ -230,6 +231,7 @@ const ReactFlow = forwardRef<ReactFlowRefType, ReactFlowProps>(
             fitViewOptions={fitViewOptions}
             onNodesDelete={onNodesDelete}
             onEdgesDelete={onEdgesDelete}
+            defaultZLevel={defaultZLevel}
           />
           {onSelectionChange && <SelectionListener onSelectionChange={onSelectionChange} />}
           {children}

--- a/src/hooks/useVisibleEdges.ts
+++ b/src/hooks/useVisibleEdges.ts
@@ -1,13 +1,12 @@
 import { useCallback } from 'react';
-
-import { useStore } from '../store';
 import { isEdgeVisible } from '../container/EdgeRenderer/utils';
-import { ReactFlowState, NodeInternals, Edge } from '../types';
+import { useStore } from '../store';
+import { Edge, NodeInternals, ReactFlowState } from '../types';
 import { isNumeric } from '../utils';
 
-const defaultEdgeTree = [{ level: 0, isMaxLevel: true, edges: [] }];
+const defaultEdgeTree = (defaultZLevel: number) => [{ level: defaultZLevel || 0, isMaxLevel: true, edges: [] }];
 
-function groupEdgesByZLevel(edges: Edge[], nodeInternals: NodeInternals) {
+function groupEdgesByZLevel(edges: Edge[], nodeInternals: NodeInternals, defaultZLevel: number) {
   let maxLevel = -1;
 
   const levelLookup = edges.reduce<Record<string, Edge[]>>((tree, edge) => {
@@ -36,13 +35,13 @@ function groupEdgesByZLevel(edges: Edge[], nodeInternals: NodeInternals) {
   });
 
   if (edgeTree.length === 0) {
-    return defaultEdgeTree;
+    return defaultEdgeTree(defaultZLevel);
   }
 
   return edgeTree;
 }
 
-function useVisibleEdges(onlyRenderVisible: boolean, nodeInternals: NodeInternals) {
+function useVisibleEdges(onlyRenderVisible: boolean, nodeInternals: NodeInternals, defaultZLevel: number) {
   const edges = useStore(
     useCallback(
       (s: ReactFlowState) => {
@@ -77,7 +76,7 @@ function useVisibleEdges(onlyRenderVisible: boolean, nodeInternals: NodeInternal
     )
   );
 
-  return groupEdgesByZLevel(edges, nodeInternals);
+  return groupEdgesByZLevel(edges, nodeInternals, defaultZLevel);
 }
 
 export default useVisibleEdges;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,32 +1,29 @@
 import create from 'zustand';
 import createContext from 'zustand/context';
-
-import { clampPosition, getDimensions } from '../utils';
-import { applyNodeChanges } from '../utils/changes';
-
-import {
-  ReactFlowState,
-  Node,
-  Edge,
-  NodeDimensionUpdate,
-  NodeDiffUpdate,
-  CoordinateExtent,
-  NodeDimensionChange,
-  EdgeSelectionChange,
-  NodeSelectionChange,
-  NodePositionChange,
-} from '../types';
 import { getHandleBounds } from '../components/Nodes/utils';
-import { createSelectionChange, getSelectionChanges } from '../utils/changes';
+import {
+  CoordinateExtent,
+  Edge,
+  EdgeSelectionChange,
+  Node,
+  NodeDiffUpdate,
+  NodeDimensionChange,
+  NodeDimensionUpdate,
+  NodePositionChange,
+  NodeSelectionChange,
+  ReactFlowState,
+} from '../types';
+import { clampPosition, getDimensions } from '../utils';
+import { applyNodeChanges, createSelectionChange, getSelectionChanges } from '../utils/changes';
+import initialState from './initialState';
 import {
   createNodeInternals,
   createPositionChange,
+  fitView,
   handleControlledEdgeSelectionChange,
   handleControlledNodeSelectionChange,
   isParentSelected,
-  fitView,
 } from './utils';
-import initialState from './initialState';
 
 const { Provider, useStore, useStoreApi } = createContext<ReactFlowState>();
 
@@ -282,6 +279,7 @@ const createStore = () =>
       });
     },
     reset: () => set({ ...initialState }),
+    setDefaultZLevel: (defaultZLevel: number) => set({ defaultZLevel }),
   }));
 
 export { Provider, useStore, createStore, useStoreApi };

--- a/src/store/initialState.ts
+++ b/src/store/initialState.ts
@@ -1,4 +1,4 @@
-import { CoordinateExtent, ReactFlowStore, ConnectionMode } from '../types';
+import { ConnectionMode, CoordinateExtent, ReactFlowStore } from '../types';
 
 export const infiniteExtent: CoordinateExtent = [
   [Number.NEGATIVE_INFINITY, Number.NEGATIVE_INFINITY],
@@ -47,6 +47,8 @@ const initialState: ReactFlowStore = {
 
   connectionStartHandle: null,
   connectOnClick: true,
+
+  defaultZLevel: 0,
 };
 
 export default initialState;

--- a/src/types/component-props.ts
+++ b/src/types/component-props.ts
@@ -32,6 +32,7 @@ import {
   OnMoveEnd,
 } from '.';
 
+
 export interface ReactFlowProps extends HTMLAttributes<HTMLDivElement> {
   nodes?: Node[];
   edges?: Edge[];
@@ -117,6 +118,7 @@ export interface ReactFlowProps extends HTMLAttributes<HTMLDivElement> {
   connectOnClick?: boolean;
   attributionPosition?: AttributionPosition;
   proOptions?: ProOptions;
+  defaultZLevel?: number,
 }
 
 export type ReactFlowRefType = HTMLDivElement;

--- a/src/types/general.ts
+++ b/src/types/general.ts
@@ -190,6 +190,7 @@ export type ReactFlowActions = {
   setTranslateExtent: (translateExtent: CoordinateExtent) => void;
   setNodeExtent: (nodeExtent: CoordinateExtent) => void;
   reset: () => void;
+  setDefaultZLevel: (defaultZLevel: number) => void;
 };
 
 export type ReactFlowState = ReactFlowStore & ReactFlowActions;

--- a/src/types/general.ts
+++ b/src/types/general.ts
@@ -1,13 +1,12 @@
-import { MouseEvent as ReactMouseEvent, ReactNode } from 'react';
 import { Selection as D3Selection, ZoomBehavior } from 'd3';
-
-import { XYPosition, Rect, Transform, CoordinateExtent } from './utils';
-import { NodeChange, EdgeChange } from './changes';
-import { Node, NodeInternals, NodeDimensionUpdate, NodeDiffUpdate } from './nodes';
+import { MouseEvent as ReactMouseEvent, ReactNode } from 'react';
+import { DefaultEdgeOptions } from '.';
+import { EdgeChange, NodeChange } from './changes';
 import { Edge } from './edges';
 import { HandleType, StartHandle } from './handles';
-import { DefaultEdgeOptions } from '.';
 import { ReactFlowInstance } from './instance';
+import { Node, NodeDiffUpdate, NodeDimensionUpdate, NodeInternals } from './nodes';
+import { CoordinateExtent, Rect, Transform, XYPosition } from './utils';
 
 export type NodeTypes = { [key: string]: ReactNode };
 export type EdgeTypes = NodeTypes;
@@ -166,6 +165,7 @@ export type ReactFlowStore = {
 
   connectOnClick: boolean;
   defaultEdgeOptions?: DefaultEdgeOptions;
+  defaultZLevel?: number;
 
   fitViewOnInit: boolean;
   fitViewOnInitDone: boolean;


### PR DESCRIPTION
I need this feature in order to fix an issue I have where the connection line goes behind my group node when there are no edges in the edge array. This can be fixed by changing the default Z level that the connection line goes in when no nodes are present.

I have no idea if I added all the necessary things to get this to work, and to be honest, I'm completely guessing. I also can't really test this myself so I have no idea if it works. It honestly might be better to just reimplement this idea however you all would usually do it.

Refer to this discord exchange for details: https://discord.com/channels/771389069270712320/859774873500778517/959992983082663986