### PR TITLE
Fix node handleBounds not updated on updateNodeInternals

### DIFF
--- a/src/utils/changes.ts
+++ b/src/utils/changes.ts
@@ -86,6 +86,12 @@ function applyChanges(changes: any[], elements: any[]): any[] {
           if (typeof currentChange.dimensions !== 'undefined') {
             updateItem.width = currentChange.dimensions.width;
             updateItem.height = currentChange.dimensions.height;
+            /**
+             * when the "dimensions" event is fired, we only change
+             * the width and the height of the current node. Now we also
+             * update the handleBounds 
+             */
+            updateItem.handleBounds = currentChange.handleBounds;
           }
 
           if (updateItem.expandParent) {


### PR DESCRIPTION
When using ```updateNodeInternals```, a ```dimensions``` event is fired, that should also update the handlers on the node. However, when reacting to the ```dimensions``` event: 
```js
 if (typeof currentChange.dimensions !== 'undefined') {
            updateItem.width = currentChange.dimensions.width;
            updateItem.height = currentChange.dimensions.height;
}
``` 
we only change the width and the height on that node, leaving the new handlers out.