### PR TITLE
added npm run build instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ function Flow({ nodes, edges, onNodesChange, onEdgesChange, onConnect }) {
 }
 ```
 
-Before you start you need to install the React Flow dependencies via `npm install` and the ones of the examples `cd example && npm install`.
+Before you start you need to build the project using `npm run build`.  Then install the React Flow dependencies via `npm install` and the ones of the examples `cd example && npm install`.
 
 If you want to contribute or develop custom features the easiest way is to start the dev server:
 


### PR DESCRIPTION
I was getting errors without running starting the example but after I ran `npm run build`, I was able to start the example