### PR TITLE
Fixed `setNodes` and `setEdges`

### DIFF
--- a/src/hooks/useReactFlow.ts
+++ b/src/hooks/useReactFlow.ts
@@ -2,7 +2,16 @@ import { useCallback } from 'react';
 
 import useViewportHelper from './useViewportHelper';
 import { useStoreApi } from '../store';
-import { ReactFlowInstance, Instance, NodeAddChange, EdgeAddChange, NodeResetChange, EdgeResetChange } from '../types';
+import {
+  ReactFlowInstance,
+  Instance,
+  NodeAddChange,
+  EdgeAddChange,
+  NodeResetChange,
+  EdgeResetChange,
+  NodeRemoveChange,
+  EdgeRemoveChange,
+} from '../types';
 
 export default function useReactFlow<NodeData = any, EdgeData = any>(): ReactFlowInstance<NodeData, EdgeData> {
   const { initialized: viewportInitialized, ...viewportHelperFunctions } = useViewportHelper();
@@ -37,7 +46,10 @@ export default function useReactFlow<NodeData = any, EdgeData = any>(): ReactFlo
     if (hasDefaultNodes) {
       setNodes(nextNodes);
     } else if (onNodesChange) {
-      const changes = nextNodes.map((node) => ({ item: node, type: 'reset' } as NodeResetChange<NodeData>));
+      const changes =
+        nextNodes.length === 0
+          ? nodes.map((node) => ({ type: 'remove', id: node.id } as NodeRemoveChange))
+          : nextNodes.map((node) => ({ item: node, type: 'reset' } as NodeResetChange<NodeData>));
       onNodesChange(changes);
     }
   }, []);
@@ -49,7 +61,10 @@ export default function useReactFlow<NodeData = any, EdgeData = any>(): ReactFlo
     if (hasDefaultEdges) {
       setEdges(nextEdges);
     } else if (onEdgesChange) {
-      const changes = nextEdges.map((edge) => ({ item: edge, type: 'reset' } as EdgeResetChange<EdgeData>));
+      const changes =
+        nextEdges.length === 0
+          ? edges.map((edge) => ({ type: 'remove', id: edge.id } as EdgeRemoveChange))
+          : nextEdges.map((edge) => ({ item: edge, type: 'reset' } as EdgeResetChange<EdgeData>));
       onEdgesChange(changes);
     }
   }, []);


### PR DESCRIPTION
This fixes #2147.

I fixed by adding a check for empty change arrays. If the change array is empty, I create a new change array that removes all edges/nodes by id.

Hacky, yes, but it doesn't change any public types. My original idea was to either:
1. Change the `reset` type to `{ items: Node<NodeData>[]; type: 'reset'; }`,
1. Change the `reset` type to `{ item: Node<NodeData> | undefined; type: 'reset'; }`, or
1. Add a new change type `{ newItems: Node<NodeData>[]; type: 'reset-all'; }`

However, all of those are a breaking change because it would change the public API of `on{Nodes,Edges}Change` and `{Node,Edge}Change`.

---

Also, when running `npm test`, I just get this:

```ps
PS C:\Users\micha\Git\react-flow> npm test

> react-flow-renderer@10.2.2 test
> BROWSER=none npm run dev:wait test:chrome

Der Befehl "BROWSER" ist entweder falsch geschrieben oder
konnte nicht gefunden werden.
```

Since Microsoft decided that translated technical error messages are a good thing, I'll translate the last line: "The command "BROWSER" is either mistyped or could not be found."

Pretty sure that setting env variables like this is (ba)sh syntax, so it won't work in PowerShell. See [this](https://stackoverflow.com/a/27090755/7595472) for more info.