### PR TITLE
Implemented allowPanOverNodes and selectionKeyCode as boolean

### DIFF
--- a/example/src/SaveRestore/save.css
+++ b/example/src/SaveRestore/save.css
@@ -2,7 +2,7 @@
   position: absolute;
   right: 10px;
   top: 10px;
-  z-index: 4;
+  z-index: 5;
   font-size: 12px;
 }
 

--- a/example/src/UpdateNode/updatenode.css
+++ b/example/src/UpdateNode/updatenode.css
@@ -2,7 +2,7 @@
   position: absolute;
   right: 10px;
   top: 10px;
-  z-index: 4;
+  z-index: 5;
   font-size: 12px;
 }
 

--- a/src/components/Edges/wrapEdge.tsx
+++ b/src/components/Edges/wrapEdge.tsx
@@ -13,7 +13,7 @@ const selector = (s: ReactFlowState) => ({
   connectionMode: s.connectionMode,
 });
 
-export default (EdgeComponent: ComponentType<EdgeProps>, allowPanOverNodes: boolean) => {
+export default (EdgeComponent: ComponentType<EdgeProps>) => {
   const EdgeWrapper = ({
     id,
     className,
@@ -52,6 +52,7 @@ export default (EdgeComponent: ComponentType<EdgeProps>, allowPanOverNodes: bool
     onEdgeUpdateEnd,
     markerEnd,
     markerStart,
+    allowPanOverNodes,
   }: WrapEdgeProps): JSX.Element | null => {
     const store = useStoreApi();
     const { addSelectedEdges, connectionMode } = useStore(selector, shallow);

--- a/src/components/Edges/wrapEdge.tsx
+++ b/src/components/Edges/wrapEdge.tsx
@@ -13,7 +13,7 @@ const selector = (s: ReactFlowState) => ({
   connectionMode: s.connectionMode,
 });
 
-export default (EdgeComponent: ComponentType<EdgeProps>) => {
+export default (EdgeComponent: ComponentType<EdgeProps>, allowPanOverNodes: boolean) => {
   const EdgeWrapper = ({
     id,
     className,
@@ -64,7 +64,7 @@ export default (EdgeComponent: ComponentType<EdgeProps>) => {
       'react-flow__edge',
       `react-flow__edge-${type}`,
       className,
-      { selected, animated, inactive, updating },
+      { selected, animated, inactive, updating, unclickable: allowPanOverNodes },
     ]);
 
     const edgeElement = useMemo<Edge>(() => {

--- a/src/components/Nodes/wrapNode.tsx
+++ b/src/components/Nodes/wrapNode.tsx
@@ -51,6 +51,7 @@ export default (NodeComponent: ComponentType<NodeProps>) => {
     isParent,
     noPanClassName,
     noDragClassName,
+    allowPanOverNodes,
   }: WrapNodeProps) => {
     const store = useStoreApi();
     const { addSelectedNodes, unselectNodesAndEdges, updateNodePosition, updateNodeDimensions } = useStore(
@@ -228,6 +229,7 @@ export default (NodeComponent: ComponentType<NodeProps>) => {
         selected,
         selectable: isSelectable,
         parent: isParent,
+        unclickable: allowPanOverNodes,
       },
     ]);
 
@@ -280,4 +282,5 @@ export default (NodeComponent: ComponentType<NodeProps>) => {
   NodeWrapper.displayName = 'NodeWrapper';
 
   return memo(NodeWrapper);
+  memo
 };

--- a/src/components/UserSelection/index.tsx
+++ b/src/components/UserSelection/index.tsx
@@ -19,7 +19,7 @@ type SelectionRect = Rect & {
 
 type UserSelectionProps = {
   selectionKeyPressed: boolean;
-  selectionKeyCode: KeyCode | null;
+  selectionKeyCode: KeyCode | null | boolean;
   onClick: (e: MouseEvent) => void;
 };
 

--- a/src/container/EdgeRenderer/index.tsx
+++ b/src/container/EdgeRenderer/index.tsx
@@ -51,6 +51,7 @@ const selector = (s: ReactFlowState) => ({
   height: s.height,
   connectionMode: s.connectionMode,
   nodeInternals: s.nodeInternals,
+  allowPanOverNodes: s.allowPanOverNodes,
 });
 
 const EdgeRenderer = (props: EdgeRendererProps) => {
@@ -65,6 +66,7 @@ const EdgeRenderer = (props: EdgeRendererProps) => {
     height,
     connectionMode,
     nodeInternals,
+    allowPanOverNodes,
   } = useStore(selector, shallow);
   const edgeTree = useVisibleEdges(props.onlyRenderVisibleElements, nodeInternals, props.elevateEdgesOnSelect);
 
@@ -138,6 +140,7 @@ const EdgeRenderer = (props: EdgeRendererProps) => {
 
               return (
                 <EdgeComponent
+                  allowPanOverNodes={allowPanOverNodes}
                   key={edge.id}
                   id={edge.id}
                   className={cc([edge.className, props.noPanClassName])}

--- a/src/container/EdgeRenderer/utils.ts
+++ b/src/container/EdgeRenderer/utils.ts
@@ -15,22 +15,22 @@ import {
 } from '../../types';
 import { rectToBox } from '../../utils';
 
-export type CreateEdgeTypes = (edgeTypes: EdgeTypes) => EdgeTypesWrapped;
+export type CreateEdgeTypes = (edgeTypes: EdgeTypes, allowPanOverNodes: boolean) => EdgeTypesWrapped;
 
-export function createEdgeTypes(edgeTypes: EdgeTypes): EdgeTypesWrapped {
+export function createEdgeTypes(edgeTypes: EdgeTypes, allowPanOverNodes: boolean): EdgeTypesWrapped {
   const standardTypes: EdgeTypesWrapped = {
-    default: wrapEdge((edgeTypes.default || BezierEdge) as ComponentType<EdgeProps>),
-    straight: wrapEdge((edgeTypes.bezier || StraightEdge) as ComponentType<EdgeProps>),
-    step: wrapEdge((edgeTypes.step || StepEdge) as ComponentType<EdgeProps>),
-    smoothstep: wrapEdge((edgeTypes.step || SmoothStepEdge) as ComponentType<EdgeProps>),
-    simplebezier: wrapEdge((edgeTypes.simplebezier || SimpleBezierEdge) as ComponentType<EdgeProps>),
+    default: wrapEdge((edgeTypes.default || BezierEdge) as ComponentType<EdgeProps>, allowPanOverNodes),
+    straight: wrapEdge((edgeTypes.bezier || StraightEdge) as ComponentType<EdgeProps>, allowPanOverNodes),
+    step: wrapEdge((edgeTypes.step || StepEdge) as ComponentType<EdgeProps>, allowPanOverNodes),
+    smoothstep: wrapEdge((edgeTypes.step || SmoothStepEdge) as ComponentType<EdgeProps>, allowPanOverNodes),
+    simplebezier: wrapEdge((edgeTypes.simplebezier || SimpleBezierEdge) as ComponentType<EdgeProps>, allowPanOverNodes),
   };
 
   const wrappedTypes = {} as EdgeTypesWrapped;
   const specialTypes: EdgeTypesWrapped = Object.keys(edgeTypes)
     .filter((k) => !['default', 'bezier'].includes(k))
     .reduce((res, key) => {
-      res[key] = wrapEdge((edgeTypes[key] || BezierEdge) as ComponentType<EdgeProps>);
+      res[key] = wrapEdge((edgeTypes[key] || BezierEdge) as ComponentType<EdgeProps>, allowPanOverNodes);
 
       return res;
     }, wrappedTypes);

--- a/src/container/EdgeRenderer/utils.ts
+++ b/src/container/EdgeRenderer/utils.ts
@@ -15,22 +15,22 @@ import {
 } from '../../types';
 import { rectToBox } from '../../utils';
 
-export type CreateEdgeTypes = (edgeTypes: EdgeTypes, allowPanOverNodes: boolean) => EdgeTypesWrapped;
+export type CreateEdgeTypes = (edgeTypes: EdgeTypes) => EdgeTypesWrapped;
 
-export function createEdgeTypes(edgeTypes: EdgeTypes, allowPanOverNodes: boolean): EdgeTypesWrapped {
+export function createEdgeTypes(edgeTypes: EdgeTypes): EdgeTypesWrapped {
   const standardTypes: EdgeTypesWrapped = {
-    default: wrapEdge((edgeTypes.default || BezierEdge) as ComponentType<EdgeProps>, allowPanOverNodes),
-    straight: wrapEdge((edgeTypes.bezier || StraightEdge) as ComponentType<EdgeProps>, allowPanOverNodes),
-    step: wrapEdge((edgeTypes.step || StepEdge) as ComponentType<EdgeProps>, allowPanOverNodes),
-    smoothstep: wrapEdge((edgeTypes.step || SmoothStepEdge) as ComponentType<EdgeProps>, allowPanOverNodes),
-    simplebezier: wrapEdge((edgeTypes.simplebezier || SimpleBezierEdge) as ComponentType<EdgeProps>, allowPanOverNodes),
+    default: wrapEdge((edgeTypes.default || BezierEdge) as ComponentType<EdgeProps>),
+    straight: wrapEdge((edgeTypes.bezier || StraightEdge) as ComponentType<EdgeProps>),
+    step: wrapEdge((edgeTypes.step || StepEdge) as ComponentType<EdgeProps>),
+    smoothstep: wrapEdge((edgeTypes.step || SmoothStepEdge) as ComponentType<EdgeProps>),
+    simplebezier: wrapEdge((edgeTypes.simplebezier || SimpleBezierEdge) as ComponentType<EdgeProps>),
   };
 
   const wrappedTypes = {} as EdgeTypesWrapped;
   const specialTypes: EdgeTypesWrapped = Object.keys(edgeTypes)
     .filter((k) => !['default', 'bezier'].includes(k))
     .reduce((res, key) => {
-      res[key] = wrapEdge((edgeTypes[key] || BezierEdge) as ComponentType<EdgeProps>, allowPanOverNodes);
+      res[key] = wrapEdge((edgeTypes[key] || BezierEdge) as ComponentType<EdgeProps>);
 
       return res;
     }, wrappedTypes);

--- a/src/container/FlowRenderer/index.tsx
+++ b/src/container/FlowRenderer/index.tsx
@@ -63,7 +63,7 @@ const FlowRenderer = ({
 }: FlowRendererProps) => {
   const store = useStoreApi();
   const { resetSelectedElements, nodesSelectionActive } = useStore(selector, shallow);
-  const selectionKeyPressed = useKeyPress(selectionKeyCode);
+  const selectionKeyPressed = useKeyPress(typeof selectionKeyCode === 'boolean' ? null : selectionKeyCode);
 
   useGlobalKeyHandler({ deleteKeyCode, multiSelectionKeyCode });
 

--- a/src/container/FlowRenderer/index.tsx
+++ b/src/container/FlowRenderer/index.tsx
@@ -102,7 +102,7 @@ const FlowRenderer = ({
       noPanClassName={noPanClassName}
     >
       {children}
-      <UserSelection selectionKeyPressed={selectionKeyPressed} />
+      <UserSelection selectionKeyCode={selectionKeyCode} onClick={onClick} selectionKeyPressed={selectionKeyPressed} />
       {nodesSelectionActive && (
         <NodesSelection
           onSelectionDragStart={onSelectionDragStart}

--- a/src/container/GraphView/index.tsx
+++ b/src/container/GraphView/index.tsx
@@ -8,10 +8,10 @@ import useOnInitHandler from '../../hooks/useOnInitHandler';
 import { NodeTypesWrapped, EdgeTypesWrapped, ConnectionLineType, KeyCode, ReactFlowProps } from '../../types';
 
 export interface GraphViewProps
-  extends Omit<ReactFlowProps, 'onSelectionChange' | 'nodes' | 'edges' | 'nodeTypes' | 'edgeTypes'> {
+  extends Omit<ReactFlowProps, 'onSelectionChange' | 'nodes' | 'edges' | 'nodeTypes' | 'edgeTypes' | 'selectionKeyCode'> {
   nodeTypes: NodeTypesWrapped;
   edgeTypes: EdgeTypesWrapped;
-  selectionKeyCode: KeyCode | null;
+  selectionKeyCode: KeyCode | null | boolean;
   deleteKeyCode: KeyCode | null;
   multiSelectionKeyCode: KeyCode | null;
   connectionLineType: ConnectionLineType;

--- a/src/container/NodeRenderer/index.tsx
+++ b/src/container/NodeRenderer/index.tsx
@@ -31,10 +31,11 @@ const selector = (s: ReactFlowState) => ({
   snapGrid: s.snapGrid,
   snapToGrid: s.snapToGrid,
   nodeInternals: s.nodeInternals,
+  allowPanOverNodes: s.allowPanOverNodes,
 });
 
 const NodeRenderer = (props: NodeRendererProps) => {
-  const { scale, nodesDraggable, nodesConnectable, elementsSelectable, updateNodeDimensions, snapGrid, snapToGrid } =
+  const { scale, nodesDraggable, nodesConnectable, elementsSelectable, updateNodeDimensions, snapGrid, snapToGrid, allowPanOverNodes } =
     useStore(selector, shallow);
   const nodes = useVisibleNodes(props.onlyRenderVisibleElements);
   const resizeObserverRef = useRef<ResizeObserver>();
@@ -88,6 +89,7 @@ const NodeRenderer = (props: NodeRendererProps) => {
           <NodeComponent
             key={node.id}
             id={node.id}
+            allowPanOverNodes={allowPanOverNodes}
             className={node.className}
             style={node.style}
             type={nodeType}

--- a/src/container/ReactFlow/index.tsx
+++ b/src/container/ReactFlow/index.tsx
@@ -1,5 +1,5 @@
 import cc from 'classcat';
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useEffect } from 'react';
 import Attribution from '../../components/Attribution';
 import { BezierEdge, SmoothStepEdge, StepEdge, StraightEdge, SimpleBezierEdge } from '../../components/Edges';
 import DefaultNode from '../../components/Nodes/DefaultNode';
@@ -25,6 +25,8 @@ import GraphView from '../GraphView';
 import { createNodeTypes } from '../NodeRenderer/utils';
 import { injectStyle, useNodeOrEdgeTypes } from './utils';
 import Wrapper from './Wrapper';
+import { useStore } from '../../store';
+import { ReactFlowState } from '../../types';
 
 if (__INJECT_STYLES__) {
   injectStyle(css as unknown as string);
@@ -47,6 +49,8 @@ const defaultEdgeTypes: EdgeTypes = {
 
 const initSnapGrid: [number, number] = [15, 15];
 const initDefaultPosition: [number, number] = [0, 0];
+
+const setAllowPanOverNodesSelector = (s: ReactFlowState) => s.setAllowPanOverNodes;
 
 const ReactFlow = forwardRef<ReactFlowRefType, ReactFlowProps>(
   (
@@ -138,13 +142,19 @@ const ReactFlow = forwardRef<ReactFlowRefType, ReactFlowProps>(
       proOptions,
       defaultEdgeOptions,
       elevateEdgesOnSelect = false,
+      allowPanOverNodes = false,
       ...rest
     },
     ref
   ) => {
+    const setAllowPanOverNodes = useStore(setAllowPanOverNodesSelector);
     const nodeTypesWrapped = useNodeOrEdgeTypes(nodeTypes, createNodeTypes) as NodeTypesWrapped;
     const edgeTypesWrapped = useNodeOrEdgeTypes(edgeTypes, createEdgeTypes) as EdgeTypesWrapped;
     const reactFlowClasses = cc(['react-flow', className]);
+
+    useEffect(() => {
+      setAllowPanOverNodes(allowPanOverNodes && panOnDrag)
+    }, [allowPanOverNodes, panOnDrag])
 
     return (
       <div {...rest} ref={ref} className={reactFlowClasses}>

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -33,6 +33,9 @@ const { Provider, useStore, useStoreApi } = createContext<ReactFlowState>();
 const createStore = () =>
   create<ReactFlowState>((set, get) => ({
     ...initialState,
+    setAllowPanOverNodes: (allow: boolean) => {
+      set({ allowPanOverNodes: allow });
+    },
     setNodes: (nodes: Node[]) => {
       set({ nodeInternals: createNodeInternals(nodes, get().nodeInternals) });
     },

--- a/src/store/initialState.ts
+++ b/src/store/initialState.ts
@@ -15,6 +15,7 @@ const initialState: ReactFlowStore = {
   onEdgesChange: null,
   hasDefaultNodes: false,
   hasDefaultEdges: false,
+  allowPanOverNodes: false,
   selectedNodesBbox: { x: 0, y: 0, width: 0, height: 0 },
   d3Zoom: null,
   d3Selection: null,

--- a/src/style.css
+++ b/src/style.css
@@ -1,3 +1,7 @@
+.unclickable {
+  pointer-events: none !important;
+}
+
 .react-flow {
   width: 100%;
   height: 100%;
@@ -14,7 +18,8 @@
 }
 
 .react-flow__pane {
-  z-index: 1;
+  z-index: 2;
+  pointer-events: none;
 }
 
 .react-flow__viewport {
@@ -24,11 +29,15 @@
 }
 
 .react-flow__renderer {
-  z-index: 4;
+  z-index: 5;
 }
 
 .react-flow__selectionpane {
-  z-index: 5;
+  z-index: 1;
+}
+
+.react-flow__selectionpane.active {
+  z-index: 3;
 }
 
 .react-flow .react-flow__edges {
@@ -90,7 +99,7 @@
 }
 
 .react-flow__nodesselection {
-  z-index: 3;
+  z-index: 4;
   transform-origin: left top;
   pointer-events: none;
 
@@ -143,7 +152,7 @@
 
 .react-flow__controls {
   position: absolute;
-  z-index: 5;
+  z-index: 6;
   bottom: 20px;
   left: 15px;
 
@@ -160,7 +169,7 @@
 
 .react-flow__minimap {
   position: absolute;
-  z-index: 5;
+  z-index: 6;
   bottom: 20px;
   right: 15px;
 }

--- a/src/types/component-props.ts
+++ b/src/types/component-props.ts
@@ -125,6 +125,7 @@ export interface ReactFlowProps extends HTMLAttributes<HTMLDivElement> {
   attributionPosition?: AttributionPosition;
   proOptions?: ProOptions;
   elevateEdgesOnSelect?: boolean;
+  allowPanOverNodes?: boolean;
 }
 
 export type ReactFlowRefType = HTMLDivElement;

--- a/src/types/component-props.ts
+++ b/src/types/component-props.ts
@@ -82,7 +82,7 @@ export interface ReactFlowProps extends HTMLAttributes<HTMLDivElement> {
   connectionLineStyle?: CSSProperties;
   connectionLineComponent?: ConnectionLineComponent;
   deleteKeyCode?: KeyCode | null;
-  selectionKeyCode?: KeyCode | null;
+  selectionKeyCode?: KeyCode | null | boolean;
   multiSelectionKeyCode?: KeyCode | null;
   zoomActivationKeyCode?: KeyCode;
   snapToGrid?: boolean;

--- a/src/types/edges.ts
+++ b/src/types/edges.ts
@@ -88,6 +88,7 @@ export interface WrapEdgeProps<T = any> {
   className?: string;
   type: string;
   data?: T;
+  allowPanOverNodes: boolean;
   onClick?: EdgeMouseHandler;
   onEdgeDoubleClick?: EdgeMouseHandler;
   selected: boolean;

--- a/src/types/general.ts
+++ b/src/types/general.ts
@@ -126,6 +126,7 @@ export type ReactFlowStore = {
   nodeInternals: NodeInternals;
   edges: Edge[];
   selectedNodesBbox: Rect;
+  allowPanOverNodes: boolean;
   onNodesChange: OnNodesChange | null;
   onEdgesChange: OnEdgesChange | null;
   hasDefaultNodes: boolean;
@@ -180,6 +181,7 @@ export type ReactFlowStore = {
 export type ReactFlowActions = {
   setNodes: (nodes: Node[]) => void;
   setEdges: (edges: Edge[]) => void;
+  setAllowPanOverNodes: (allow: boolean) => void;
   setDefaultNodesAndEdges: (nodes?: Node[], edges?: Edge[]) => void;
   updateNodeDimensions: (updates: NodeDimensionUpdate[]) => void;
   updateNodePosition: (update: NodeDiffUpdate) => void;

--- a/src/types/nodes.ts
+++ b/src/types/nodes.ts
@@ -58,6 +58,7 @@ export interface WrapNodeProps<T = any> {
   type: string;
   data: T;
   selected: boolean;
+  allowPanOverNodes: boolean;
   isConnectable: boolean;
   scale: number;
   xPos: number;


### PR DESCRIPTION
I'm not sure if this is the most performing way to do this, but I needed, so I did it.

This should address #1001 and #964, an updated version of #1156.

Basically now you can set `selectionKeyCode` as a boolean (true or false, I couldn't decide what was best) and that basically turns select mode on forever.

I also added the prop `allowPanOverNodes`, a boolean that, when turned on, sets an internal state in zustand that is used in the `<NodeRenderer />` and `<EdgeRenderer />` components, passed to the `<NodeComponent />` and `<EdgeComponent />` components and finally, in `wrapEdge.tsx` and `wrapNode.tsx` files, gets translated to a new class called `.unclickable`, which adds `pointer-events: none !important;` to the draggable elements.

Basically with a combination of the PR and three props: `panOnDrag={spacePressed}`, `allowPanOverNodes` and `selectionKeyCode={true}`, we get a Figma like experience.

It's a bit hacky and I had to change z-index values, but it works.

What do you think?