### PR TITLE
Unselect selected nodes when multiselecting

### DIFF
--- a/src/components/Nodes/wrapNode.tsx
+++ b/src/components/Nodes/wrapNode.tsx
@@ -10,6 +10,7 @@ import useMemoizedMouseHandler from './useMemoizedMouseHandler';
 
 const selector = (s: ReactFlowState) => ({
   addSelectedNodes: s.addSelectedNodes,
+  unselectNodes: s.unselectNodes,
   updateNodePosition: s.updateNodePosition,
   unselectNodesAndEdges: s.unselectNodesAndEdges,
   updateNodeDimensions: s.updateNodeDimensions,
@@ -53,7 +54,7 @@ export default (NodeComponent: ComponentType<NodeProps>) => {
     noDragClassName,
   }: WrapNodeProps) => {
     const store = useStoreApi();
-    const { addSelectedNodes, unselectNodesAndEdges, updateNodePosition, updateNodeDimensions } = useStore(
+    const { addSelectedNodes, unselectNodes, unselectNodesAndEdges, updateNodePosition, updateNodeDimensions } = useStore(
       selector,
       shallow
     );
@@ -88,9 +89,11 @@ export default (NodeComponent: ComponentType<NodeProps>) => {
         if (!isDraggable) {
           if (isSelectable) {
             store.setState({ nodesSelectionActive: false });
-
+            const { multiSelectionActive } = store.getState();
             if (!selected) {
               addSelectedNodes([id]);
+            } else if (multiSelectionActive) {
+              unselectNodes([id]);            
             }
           }
 
@@ -105,14 +108,16 @@ export default (NodeComponent: ComponentType<NodeProps>) => {
 
     const onDragStart = useCallback(
       (event: DraggableEvent) => {
+        const { multiSelectionActive } = store.getState();
         if (selectNodesOnDrag && isSelectable) {
           store.setState({ nodesSelectionActive: false });
 
           if (!selected) {
             addSelectedNodes([id]);
+          } else if (multiSelectionActive) {
+            unselectNodes([id]);
           }
         } else if (!selectNodesOnDrag && !selected && isSelectable) {
-          const { multiSelectionActive } = store.getState();
           if (multiSelectionActive) {
             addSelectedNodes([id]);
           } else {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -125,7 +125,6 @@ const createStore = () =>
     },
     unselectNodes: (selectedNodeIds: string[]) => {
       const { onNodesChange, nodeInternals, hasDefaultNodes } = get();
-      console.log('olha')
 
       const changedNodes: NodeSelectionChange[] = selectedNodeIds.map((nodeId) =>
         createSelectionChange(nodeId, false)

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -123,6 +123,22 @@ const createStore = () =>
         }
       }
     },
+    unselectNodes: (selectedNodeIds: string[]) => {
+      const { onNodesChange, nodeInternals, hasDefaultNodes } = get();
+      console.log('olha')
+
+      const changedNodes: NodeSelectionChange[] = selectedNodeIds.map((nodeId) =>
+        createSelectionChange(nodeId, false)
+      ) as NodeSelectionChange[];
+
+      if (changedNodes.length) {
+        if (hasDefaultNodes) {
+          set({ nodeInternals: handleControlledNodeSelectionChange(changedNodes, nodeInternals) });
+        }
+
+        onNodesChange?.(changedNodes);
+      }
+    },
     // @TODO: can we unify addSelectedNodes and addSelectedEdges somehow?
     addSelectedNodes: (selectedNodeIds: string[]) => {
       const {

--- a/src/types/general.ts
+++ b/src/types/general.ts
@@ -186,6 +186,7 @@ export type ReactFlowActions = {
   resetSelectedElements: () => void;
   unselectNodesAndEdges: () => void;
   addSelectedNodes: (nodeIds: string[]) => void;
+  unselectNodes: (edgeIds: string[]) => void;
   addSelectedEdges: (edgeIds: string[]) => void;
   setMinZoom: (minZoom: number) => void;
   setMaxZoom: (maxZoom: number) => void;


### PR DESCRIPTION
This PR addresses #1462 and probably others I couldn't find.
While pressing `multiSelectionKey`, the expected behavior when the user clicks some already selected nodes is unselect it. This PR implement that.