### PR TITLE
Added `connectionLineContainerStyle` property

### DIFF
--- a/src/container/EdgeRenderer/index.tsx
+++ b/src/container/EdgeRenderer/index.tsx
@@ -93,7 +93,7 @@ const EdgeRenderer = (props: EdgeRendererProps) => {
           style={{ zIndex: level }}
           width={width}
           height={height}
-          className="react-flow__edges react-flow__connectionline react-flow__container"
+          className="react-flow__edges react-flow__container"
         >
           {isMaxLevel && <MarkerDefinitions defaultColor={defaultMarkerColor} />}
           <g>
@@ -196,7 +196,7 @@ const EdgeRenderer = (props: EdgeRendererProps) => {
         style={connectionLineContainerStyle}
         width={width}
         height={height}
-        className="react-flow__edges react-flow__container"
+        className="react-flow__edges react-flow__connectionline react-flow__container"
       >
         <g>
           <ConnectionLine

--- a/src/container/EdgeRenderer/index.tsx
+++ b/src/container/EdgeRenderer/index.tsx
@@ -73,7 +73,13 @@ const EdgeRenderer = (props: EdgeRendererProps) => {
     return null;
   }
 
-  const { connectionLineType, defaultMarkerColor, connectionLineStyle, connectionLineComponent, connectionLineContainerStyle } = props;
+  const {
+    connectionLineType,
+    defaultMarkerColor,
+    connectionLineStyle,
+    connectionLineComponent,
+    connectionLineContainerStyle,
+  } = props;
   const renderConnectionLine = connectionNodeId && connectionHandleType;
 
   return (
@@ -183,26 +189,28 @@ const EdgeRenderer = (props: EdgeRendererProps) => {
           </g>
         </svg>
       ))}
-      {renderConnectionLine && <svg
-        style={connectionLineContainerStyle}
-        width={width}
-        height={height}
-        className="react-flow__edges react-flow__connectionline react-flow__container"
-      >
-        <g>
-          <ConnectionLine
-            connectionNodeId={connectionNodeId!}
-            connectionHandleId={connectionHandleId}
-            connectionHandleType={connectionHandleType!}
-            connectionPositionX={connectionPosition.x}
-            connectionPositionY={connectionPosition.y}
-            connectionLineStyle={connectionLineStyle}
-            connectionLineType={connectionLineType}
-            isConnectable={nodesConnectable}
-            CustomConnectionLineComponent={connectionLineComponent}
-          />
-        </g>
-      </svg>}
+      {renderConnectionLine && (
+        <svg
+          style={connectionLineContainerStyle}
+          width={width}
+          height={height}
+          className="react-flow__edges react-flow__connectionline react-flow__container"
+        >
+          <g>
+            <ConnectionLine
+              connectionNodeId={connectionNodeId!}
+              connectionHandleId={connectionHandleId}
+              connectionHandleType={connectionHandleType!}
+              connectionPositionX={connectionPosition.x}
+              connectionPositionY={connectionPosition.y}
+              connectionLineStyle={connectionLineStyle}
+              connectionLineType={connectionLineType}
+              isConnectable={nodesConnectable}
+              CustomConnectionLineComponent={connectionLineComponent}
+            />
+          </g>
+        </svg>
+      )}
     </>
   );
 };

--- a/src/container/EdgeRenderer/index.tsx
+++ b/src/container/EdgeRenderer/index.tsx
@@ -24,6 +24,7 @@ interface EdgeRendererProps {
   connectionLineType: ConnectionLineType;
   connectionLineStyle?: CSSProperties;
   connectionLineComponent?: ConnectionLineComponent;
+  connectionLineContainerStyle?: CSSProperties;
   onEdgeClick?: (event: React.MouseEvent, node: Edge) => void;
   onEdgeDoubleClick?: (event: React.MouseEvent, edge: Edge) => void;
   defaultMarkerColor: string;
@@ -74,6 +75,15 @@ const EdgeRenderer = (props: EdgeRendererProps) => {
 
   const { connectionLineType, defaultMarkerColor, connectionLineStyle, connectionLineComponent } = props;
   const renderConnectionLine = connectionNodeId && connectionHandleType;
+
+  let { connectionLineContainerStyle } = props
+  if (connectionLineContainerStyle?.zIndex === undefined) {
+    // if not set already, set the zIndex to the max level of the any edge
+    connectionLineContainerStyle = {
+      ...connectionLineContainerStyle,
+      zIndex: edgeTree.find(({ isMaxLevel }) => isMaxLevel)?.level
+    }
+  }
 
   return (
     <>
@@ -179,22 +189,29 @@ const EdgeRenderer = (props: EdgeRendererProps) => {
                 />
               );
             })}
-            {renderConnectionLine && isMaxLevel && (
-              <ConnectionLine
-                connectionNodeId={connectionNodeId!}
-                connectionHandleId={connectionHandleId}
-                connectionHandleType={connectionHandleType!}
-                connectionPositionX={connectionPosition.x}
-                connectionPositionY={connectionPosition.y}
-                connectionLineStyle={connectionLineStyle}
-                connectionLineType={connectionLineType}
-                isConnectable={nodesConnectable}
-                CustomConnectionLineComponent={connectionLineComponent}
-              />
-            )}
           </g>
         </svg>
       ))}
+      {renderConnectionLine && <svg
+        style={connectionLineContainerStyle}
+        width={width}
+        height={height}
+        className="react-flow__edges react-flow__container"
+      >
+        <g>
+          <ConnectionLine
+            connectionNodeId={connectionNodeId!}
+            connectionHandleId={connectionHandleId}
+            connectionHandleType={connectionHandleType!}
+            connectionPositionX={connectionPosition.x}
+            connectionPositionY={connectionPosition.y}
+            connectionLineStyle={connectionLineStyle}
+            connectionLineType={connectionLineType}
+            isConnectable={nodesConnectable}
+            CustomConnectionLineComponent={connectionLineComponent}
+          />
+        </g>
+      </svg>}
     </>
   );
 };

--- a/src/container/EdgeRenderer/index.tsx
+++ b/src/container/EdgeRenderer/index.tsx
@@ -93,7 +93,7 @@ const EdgeRenderer = (props: EdgeRendererProps) => {
           style={{ zIndex: level }}
           width={width}
           height={height}
-          className="react-flow__edges react-flow__container"
+          className="react-flow__edges react-flow__connectionline react-flow__container"
         >
           {isMaxLevel && <MarkerDefinitions defaultColor={defaultMarkerColor} />}
           <g>

--- a/src/container/EdgeRenderer/index.tsx
+++ b/src/container/EdgeRenderer/index.tsx
@@ -73,17 +73,8 @@ const EdgeRenderer = (props: EdgeRendererProps) => {
     return null;
   }
 
-  const { connectionLineType, defaultMarkerColor, connectionLineStyle, connectionLineComponent } = props;
+  const { connectionLineType, defaultMarkerColor, connectionLineStyle, connectionLineComponent, connectionLineContainerStyle } = props;
   const renderConnectionLine = connectionNodeId && connectionHandleType;
-
-  let { connectionLineContainerStyle } = props
-  if (connectionLineContainerStyle?.zIndex === undefined) {
-    // if not set already, set the zIndex to the max level of the any edge
-    connectionLineContainerStyle = {
-      ...connectionLineContainerStyle,
-      zIndex: edgeTree.find(({ isMaxLevel }) => isMaxLevel)?.level
-    }
-  }
 
   return (
     <>

--- a/src/container/FlowRenderer/index.tsx
+++ b/src/container/FlowRenderer/index.tsx
@@ -18,6 +18,7 @@ interface FlowRendererProps
     | 'edgeTypes'
     | 'snapGrid'
     | 'connectionLineType'
+    | 'connectionLineContainerStyle'
     | 'arrowHeadColor'
     | 'onlyRenderVisibleElements'
     | 'selectNodesOnDrag'

--- a/src/container/GraphView/index.tsx
+++ b/src/container/GraphView/index.tsx
@@ -50,6 +50,7 @@ const GraphView = ({
   connectionLineType,
   connectionLineStyle,
   connectionLineComponent,
+  connectionLineContainerStyle,
   selectionKeyCode,
   multiSelectionKeyCode,
   zoomActivationKeyCode,
@@ -125,6 +126,7 @@ const GraphView = ({
           connectionLineType={connectionLineType}
           connectionLineStyle={connectionLineStyle}
           connectionLineComponent={connectionLineComponent}
+          connectionLineContainerStyle={connectionLineContainerStyle}
           onEdgeUpdate={onEdgeUpdate}
           onlyRenderVisibleElements={onlyRenderVisibleElements}
           onEdgeContextMenu={onEdgeContextMenu}

--- a/src/container/ReactFlow/index.tsx
+++ b/src/container/ReactFlow/index.tsx
@@ -87,6 +87,7 @@ const ReactFlow = forwardRef<ReactFlowRefType, ReactFlowProps>(
       connectionLineType = ConnectionLineType.Bezier,
       connectionLineStyle,
       connectionLineComponent,
+      connectionLineContainerStyle,
       deleteKeyCode = 'Backspace',
       selectionKeyCode = 'Shift',
       multiSelectionKeyCode = 'Meta',
@@ -169,6 +170,7 @@ const ReactFlow = forwardRef<ReactFlowRefType, ReactFlowProps>(
             connectionLineType={connectionLineType}
             connectionLineStyle={connectionLineStyle}
             connectionLineComponent={connectionLineComponent}
+            connectionLineContainerStyle={connectionLineContainerStyle}
             selectionKeyCode={selectionKeyCode}
             deleteKeyCode={deleteKeyCode}
             multiSelectionKeyCode={multiSelectionKeyCode}

--- a/src/style.css
+++ b/src/style.css
@@ -36,6 +36,10 @@
   overflow: visible;
 }
 
+.react-flow .react-flow__connectionline {
+  z-index: 1001;
+}
+
 .react-flow__edge {
   pointer-events: visibleStroke;
 

--- a/src/types/component-props.ts
+++ b/src/types/component-props.ts
@@ -81,6 +81,7 @@ export interface ReactFlowProps extends HTMLAttributes<HTMLDivElement> {
   connectionLineType?: ConnectionLineType;
   connectionLineStyle?: CSSProperties;
   connectionLineComponent?: ConnectionLineComponent;
+  connectionLineContainerStyle?: CSSProperties;
   deleteKeyCode?: KeyCode | null;
   selectionKeyCode?: KeyCode | null;
   multiSelectionKeyCode?: KeyCode | null;


### PR DESCRIPTION
This implements solution 3 from #2158.

The connection line will now always have an exclusive `<svg>` element. This makes the implementation easier. I kept the old class name to stay backward compatible. The fix suggested in #810 will continue to work.