### PR TITLE
refactor(internals): use non enumerable props

### DIFF
--- a/example/src/UseReactFlow/index.tsx
+++ b/example/src/UseReactFlow/index.tsx
@@ -33,7 +33,18 @@ const UseZoomPanHelperFlow = () => {
   const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
   const onConnect = (params: Connection | Edge) => setEdges((eds) => addEdge(params, eds));
-  const { project, setCenter, zoomIn, zoomOut, fitView, addNodes, setNodes: setNodesHook, addEdges } = useReactFlow();
+  const {
+    project,
+    setCenter,
+    zoomIn,
+    zoomOut,
+    fitView,
+    addNodes,
+    setNodes: setNodesHook,
+    addEdges,
+    getNodes,
+    getEdges,
+  } = useReactFlow();
 
   const onPaneClick = useCallback(
     (evt: MouseEvent) => {
@@ -72,6 +83,11 @@ const UseZoomPanHelperFlow = () => {
     addNodes(newNode);
   }, [addNodes]);
 
+  const logNodes = useCallback(() => {
+    console.log('nodes', getNodes());
+    console.log('edges', getEdges());
+  }, [getNodes]);
+
   useEffect(() => {
     addEdges({ id: 'e3-4', source: '3', target: '4' });
   }, [addEdges]);
@@ -97,6 +113,7 @@ const UseZoomPanHelperFlow = () => {
         <button onClick={() => fitView({ duration: 1200, padding: 0.3 })}>fitView</button>
         <button onClick={onAddNode}>add node</button>
         <button onClick={onResetNodes}>reset nodes</button>
+        <button onClick={logNodes}>useNodes</button>
       </div>
       <Background />
       <MiniMap />

--- a/src/components/ConnectionLine/index.tsx
+++ b/src/components/ConnectionLine/index.tsx
@@ -6,7 +6,7 @@ import { getBezierPath } from '../Edges/BezierEdge';
 import { getSmoothStepPath } from '../Edges/SmoothStepEdge';
 import { ConnectionLineType, ConnectionLineComponent, HandleType, Node, ReactFlowState, Position } from '../../types';
 import { getSimpleBezierPath } from '../Edges/SimpleBezierEdge';
-import { handleBoundsSymbol } from '../../utils';
+import { internalsSymbol } from '../../utils';
 
 interface ConnectionLineProps {
   connectionNodeId: string;
@@ -38,7 +38,7 @@ export default ({
 
   const { nodeInternals, transform } = useStore(selector, shallow);
   const fromNode = useRef<Node | undefined>(nodeInternals.get(nodeId));
-  const fromHandleBounds = fromNode.current?.[handleBoundsSymbol];
+  const fromHandleBounds = fromNode.current?.[internalsSymbol].handleBounds;
 
   if (!fromNode.current || !isConnectable || !fromHandleBounds?.[connectionHandleType]) {
     return null;

--- a/src/components/ConnectionLine/index.tsx
+++ b/src/components/ConnectionLine/index.tsx
@@ -6,6 +6,7 @@ import { getBezierPath } from '../Edges/BezierEdge';
 import { getSmoothStepPath } from '../Edges/SmoothStepEdge';
 import { ConnectionLineType, ConnectionLineComponent, HandleType, Node, ReactFlowState, Position } from '../../types';
 import { getSimpleBezierPath } from '../Edges/SimpleBezierEdge';
+import { handleBoundsSymbol } from '../../utils';
 
 interface ConnectionLineProps {
   connectionNodeId: string;
@@ -37,12 +38,13 @@ export default ({
 
   const { nodeInternals, transform } = useStore(selector, shallow);
   const fromNode = useRef<Node | undefined>(nodeInternals.get(nodeId));
+  const fromHandleBounds = fromNode.current?.[handleBoundsSymbol];
 
-  if (!fromNode.current || !isConnectable || !fromNode.current.handleBounds?.[connectionHandleType]) {
+  if (!fromNode.current || !isConnectable || !fromHandleBounds?.[connectionHandleType]) {
     return null;
   }
 
-  const handleBound = fromNode.current.handleBounds?.[connectionHandleType];
+  const handleBound = fromHandleBounds[connectionHandleType];
   const fromHandle = handleId ? handleBound?.find((d) => d.id === handleId) : handleBound?.[0];
   const fromHandleX = fromHandle ? fromHandle.x + fromHandle.width / 2 : (fromNode.current?.width ?? 0) / 2;
   const fromHandleY = fromHandle ? fromHandle.y + fromHandle.height / 2 : fromNode.current?.height ?? 0;

--- a/src/components/ConnectionLine/index.tsx
+++ b/src/components/ConnectionLine/index.tsx
@@ -38,7 +38,7 @@ export default ({
 
   const { nodeInternals, transform } = useStore(selector, shallow);
   const fromNode = useRef<Node | undefined>(nodeInternals.get(nodeId));
-  const fromHandleBounds = fromNode.current?.[internalsSymbol].handleBounds;
+  const fromHandleBounds = fromNode.current?.[internalsSymbol]?.handleBounds;
 
   if (!fromNode.current || !isConnectable || !fromHandleBounds?.[connectionHandleType]) {
     return null;

--- a/src/container/EdgeRenderer/utils.ts
+++ b/src/container/EdgeRenderer/utils.ts
@@ -168,7 +168,7 @@ export function isEdgeVisible({
 
 export function getNodeData(nodeInternals: NodeInternals, nodeId: string): [Rect, NodeHandleBounds | null, boolean] {
   const node = nodeInternals.get(nodeId);
-  const handleBounds = node?.[internalsSymbol].handleBounds || null;
+  const handleBounds = node?.[internalsSymbol]?.handleBounds || null;
 
   const isInvalid =
     !node ||

--- a/src/container/EdgeRenderer/utils.ts
+++ b/src/container/EdgeRenderer/utils.ts
@@ -13,7 +13,7 @@ import {
   Transform,
   XYPosition,
 } from '../../types';
-import { handleBoundsSymbol, rectToBox } from '../../utils';
+import { internalsSymbol, rectToBox } from '../../utils';
 
 export type CreateEdgeTypes = (edgeTypes: EdgeTypes) => EdgeTypesWrapped;
 
@@ -168,7 +168,7 @@ export function isEdgeVisible({
 
 export function getNodeData(nodeInternals: NodeInternals, nodeId: string): [Rect, NodeHandleBounds | null, boolean] {
   const node = nodeInternals.get(nodeId);
-  const handleBounds = node?.[handleBoundsSymbol] || null;
+  const handleBounds = node?.[internalsSymbol].handleBounds || null;
 
   const isInvalid =
     !node ||

--- a/src/container/EdgeRenderer/utils.ts
+++ b/src/container/EdgeRenderer/utils.ts
@@ -13,7 +13,7 @@ import {
   Transform,
   XYPosition,
 } from '../../types';
-import { rectToBox } from '../../utils';
+import { handleBoundsSymbol, rectToBox } from '../../utils';
 
 export type CreateEdgeTypes = (edgeTypes: EdgeTypes) => EdgeTypesWrapped;
 
@@ -168,10 +168,11 @@ export function isEdgeVisible({
 
 export function getNodeData(nodeInternals: NodeInternals, nodeId: string): [Rect, NodeHandleBounds | null, boolean] {
   const node = nodeInternals.get(nodeId);
-  const handleBounds = node?.handleBounds;
+  const handleBounds = node?.[handleBoundsSymbol] || null;
+
   const isInvalid =
     !node ||
-    !node.handleBounds ||
+    !handleBounds ||
     !node.width ||
     !node.height ||
     typeof node.positionAbsolute?.x === 'undefined' ||
@@ -184,7 +185,7 @@ export function getNodeData(nodeInternals: NodeInternals, nodeId: string): [Rect
       width: node?.width || 0,
       height: node?.height || 0,
     },
-    handleBounds || null,
+    handleBounds,
     !isInvalid,
   ];
 }

--- a/src/container/NodeRenderer/index.tsx
+++ b/src/container/NodeRenderer/index.tsx
@@ -118,8 +118,8 @@ const NodeRenderer = (props: NodeRendererProps) => {
             isConnectable={isConnectable}
             resizeObserver={resizeObserver}
             dragHandle={node.dragHandle}
-            zIndex={node[internalsSymbol].z ?? 0}
-            isParent={!!node[internalsSymbol].isParent}
+            zIndex={node[internalsSymbol]?.z ?? 0}
+            isParent={!!node[internalsSymbol]?.isParent}
             noDragClassName={props.noDragClassName}
             noPanClassName={props.noPanClassName}
           />

--- a/src/container/NodeRenderer/index.tsx
+++ b/src/container/NodeRenderer/index.tsx
@@ -11,7 +11,7 @@ import {
   ReactFlowState,
   WrapNodeProps,
 } from '../../types';
-import { isParentSymbol, zSymbol } from '../../utils';
+import { internalsSymbol } from '../../utils';
 
 interface NodeRendererProps {
   nodeTypes: NodeTypesWrapped;
@@ -118,8 +118,8 @@ const NodeRenderer = (props: NodeRendererProps) => {
             isConnectable={isConnectable}
             resizeObserver={resizeObserver}
             dragHandle={node.dragHandle}
-            zIndex={node[zSymbol] ?? 0}
-            isParent={!!node[isParentSymbol]}
+            zIndex={node[internalsSymbol].z ?? 0}
+            isParent={!!node[internalsSymbol].isParent}
             noDragClassName={props.noDragClassName}
             noPanClassName={props.noPanClassName}
           />

--- a/src/container/NodeRenderer/index.tsx
+++ b/src/container/NodeRenderer/index.tsx
@@ -11,6 +11,7 @@ import {
   ReactFlowState,
   WrapNodeProps,
 } from '../../types';
+import { isParentSymbol, zSymbol } from '../../utils';
 
 interface NodeRendererProps {
   nodeTypes: NodeTypesWrapped;
@@ -117,8 +118,8 @@ const NodeRenderer = (props: NodeRendererProps) => {
             isConnectable={isConnectable}
             resizeObserver={resizeObserver}
             dragHandle={node.dragHandle}
-            zIndex={node.z ?? 0}
-            isParent={!!node.isParent}
+            zIndex={node[zSymbol] ?? 0}
+            isParent={!!node[isParentSymbol]}
             noDragClassName={props.noDragClassName}
             noPanClassName={props.noPanClassName}
           />

--- a/src/hooks/useVisibleEdges.ts
+++ b/src/hooks/useVisibleEdges.ts
@@ -18,8 +18,8 @@ function groupEdgesByZLevel(edges: Edge[], nodeInternals: NodeInternals, elevate
       z = hasZIndex
         ? edge.zIndex!
         : Math.max(
-            nodeInternals.get(edge.source)?.[internalsSymbol].z || 0,
-            nodeInternals.get(edge.target)?.[internalsSymbol].z || 0
+            nodeInternals.get(edge.source)?.[internalsSymbol]?.z || 0,
+            nodeInternals.get(edge.target)?.[internalsSymbol]?.z || 0
           );
     }
 

--- a/src/hooks/useVisibleEdges.ts
+++ b/src/hooks/useVisibleEdges.ts
@@ -3,7 +3,7 @@ import { useCallback } from 'react';
 import { useStore } from '../store';
 import { isEdgeVisible } from '../container/EdgeRenderer/utils';
 import { ReactFlowState, NodeInternals, Edge } from '../types';
-import { isNumeric } from '../utils';
+import { isNumeric, zSymbol } from '../utils';
 
 const defaultEdgeTree = [{ level: 0, isMaxLevel: true, edges: [] }];
 
@@ -17,7 +17,7 @@ function groupEdgesByZLevel(edges: Edge[], nodeInternals: NodeInternals, elevate
     if (elevateEdgesOnSelect) {
       z = hasZIndex
         ? edge.zIndex!
-        : Math.max(nodeInternals.get(edge.source)?.z || 0, nodeInternals.get(edge.target)?.z || 0);
+        : Math.max(nodeInternals.get(edge.source)?.[zSymbol] || 0, nodeInternals.get(edge.target)?.[zSymbol] || 0);
     }
 
     if (tree[z]) {

--- a/src/hooks/useVisibleEdges.ts
+++ b/src/hooks/useVisibleEdges.ts
@@ -3,7 +3,7 @@ import { useCallback } from 'react';
 import { useStore } from '../store';
 import { isEdgeVisible } from '../container/EdgeRenderer/utils';
 import { ReactFlowState, NodeInternals, Edge } from '../types';
-import { isNumeric, zSymbol } from '../utils';
+import { internalsSymbol, isNumeric } from '../utils';
 
 const defaultEdgeTree = [{ level: 0, isMaxLevel: true, edges: [] }];
 
@@ -17,7 +17,10 @@ function groupEdgesByZLevel(edges: Edge[], nodeInternals: NodeInternals, elevate
     if (elevateEdgesOnSelect) {
       z = hasZIndex
         ? edge.zIndex!
-        : Math.max(nodeInternals.get(edge.source)?.[zSymbol] || 0, nodeInternals.get(edge.target)?.[zSymbol] || 0);
+        : Math.max(
+            nodeInternals.get(edge.source)?.[internalsSymbol].z || 0,
+            nodeInternals.get(edge.target)?.[internalsSymbol].z || 0
+          );
     }
 
     if (tree[z]) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,6 @@ export {
 } from './utils/graph';
 export { applyNodeChanges, applyEdgeChanges } from './utils/changes';
 export { getMarkerEnd, getCenter as getEdgeCenter } from './components/Edges/utils';
-export { internalsSymbol } from './utils';
 
 export { default as useReactFlow } from './hooks/useReactFlow';
 export { default as useUpdateNodeInternals } from './hooks/useUpdateNodeInternals';

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ export {
 } from './utils/graph';
 export { applyNodeChanges, applyEdgeChanges } from './utils/changes';
 export { getMarkerEnd, getCenter as getEdgeCenter } from './components/Edges/utils';
+export { internalsSymbol } from './utils';
 
 export { default as useReactFlow } from './hooks/useReactFlow';
 export { default as useUpdateNodeInternals } from './hooks/useUpdateNodeInternals';

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,7 +1,7 @@
 import create from 'zustand';
 import createContext from 'zustand/context';
 
-import { clampPosition, getDimensions, handleBoundsSymbol } from '../utils';
+import { clampPosition, getDimensions, internalsSymbol } from '../utils';
 import { applyNodeChanges } from '../utils/changes';
 import {
   ReactFlowState,
@@ -60,7 +60,10 @@ const createStore = () =>
             const handleBounds = getHandleBounds(update.nodeElement, transform[2]);
             nodeInternals.set(node.id, {
               ...node,
-              [handleBoundsSymbol]: handleBounds,
+              [internalsSymbol]: {
+                ...node[internalsSymbol],
+                handleBounds,
+              },
               ...dimensions,
             });
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,7 +1,7 @@
 import create from 'zustand';
 import createContext from 'zustand/context';
 
-import { clampPosition, getDimensions } from '../utils';
+import { clampPosition, getDimensions, handleBoundsSymbol } from '../utils';
 import { applyNodeChanges } from '../utils/changes';
 import {
   ReactFlowState,
@@ -60,7 +60,7 @@ const createStore = () =>
             const handleBounds = getHandleBounds(update.nodeElement, transform[2]);
             nodeInternals.set(node.id, {
               ...node,
-              handleBounds,
+              [handleBoundsSymbol]: handleBounds,
               ...dimensions,
             });
 

--- a/src/store/utils.ts
+++ b/src/store/utils.ts
@@ -30,7 +30,7 @@ function calculateXYZPosition(
   return calculateXYZPosition(parentNode, nodeInternals, parentNodes, {
     x: (result.x ?? 0) + (parentNode.position?.x ?? 0),
     y: (result.y ?? 0) + (parentNode.position?.y ?? 0),
-    z: (parentNode[internalsSymbol].z ?? 0) > (result.z ?? 0) ? parentNode[internalsSymbol].z ?? 0 : result.z ?? 0,
+    z: (parentNode[internalsSymbol]?.z ?? 0) > (result.z ?? 0) ? parentNode[internalsSymbol]?.z ?? 0 : result.z ?? 0,
   });
 }
 
@@ -60,7 +60,7 @@ export function createNodeInternals(nodes: Node[], nodeInternals: NodeInternals)
     Object.defineProperty(internals, internalsSymbol, {
       enumerable: false,
       value: {
-        handleBounds: currInternals?.[internalsSymbol].handleBounds,
+        handleBounds: currInternals?.[internalsSymbol]?.handleBounds,
         z,
       },
     });
@@ -76,7 +76,7 @@ export function createNodeInternals(nodes: Node[], nodeInternals: NodeInternals)
     if (node.parentNode || parentNodes[node.id]) {
       const { x, y, z } = calculateXYZPosition(node, nextNodeInternals, parentNodes, {
         ...node.position,
-        z: node[internalsSymbol].z ?? 0,
+        z: node[internalsSymbol]?.z ?? 0,
       });
 
       node.positionAbsolute = {
@@ -84,10 +84,10 @@ export function createNodeInternals(nodes: Node[], nodeInternals: NodeInternals)
         y,
       };
 
-      node[internalsSymbol].z = z;
+      node[internalsSymbol]!.z = z;
 
       if (parentNodes[node.id]) {
-        node[internalsSymbol].isParent = true;
+        node[internalsSymbol]!.isParent = true;
       }
     }
   });

--- a/src/store/utils.ts
+++ b/src/store/utils.ts
@@ -1,7 +1,7 @@
 import { zoomIdentity } from 'd3-zoom';
 import { GetState, SetState } from 'zustand';
 
-import { handleBoundsSymbol, isNumeric, isParentSymbol, zSymbol } from '../utils';
+import { internalsSymbol, isNumeric } from '../utils';
 import { getD3Transition, getRectOfNodes, getTransformForBounds } from '../utils/graph';
 import {
   Edge,
@@ -30,7 +30,7 @@ function calculateXYZPosition(
   return calculateXYZPosition(parentNode, nodeInternals, parentNodes, {
     x: (result.x ?? 0) + (parentNode.position?.x ?? 0),
     y: (result.y ?? 0) + (parentNode.position?.y ?? 0),
-    z: (parentNode[zSymbol] ?? 0) > (result.z ?? 0) ? parentNode[zSymbol] ?? 0 : result.z ?? 0,
+    z: (parentNode[internalsSymbol].z ?? 0) > (result.z ?? 0) ? parentNode[internalsSymbol].z ?? 0 : result.z ?? 0,
   });
 }
 
@@ -57,14 +57,12 @@ export function createNodeInternals(nodes: Node[], nodeInternals: NodeInternals)
       parentNodes[node.parentNode] = true;
     }
 
-    Object.defineProperty(internals, handleBoundsSymbol, {
+    Object.defineProperty(internals, internalsSymbol, {
       enumerable: false,
-      value: currInternals?.[handleBoundsSymbol],
-    });
-
-    Object.defineProperty(internals, zSymbol, {
-      enumerable: false,
-      value: z,
+      value: {
+        handleBounds: currInternals?.[internalsSymbol].handleBounds,
+        z,
+      },
     });
 
     nextNodeInternals.set(node.id, internals);
@@ -78,7 +76,7 @@ export function createNodeInternals(nodes: Node[], nodeInternals: NodeInternals)
     if (node.parentNode || parentNodes[node.id]) {
       const { x, y, z } = calculateXYZPosition(node, nextNodeInternals, parentNodes, {
         ...node.position,
-        z: node[zSymbol] ?? 0,
+        z: node[internalsSymbol].z ?? 0,
       });
 
       node.positionAbsolute = {
@@ -86,10 +84,10 @@ export function createNodeInternals(nodes: Node[], nodeInternals: NodeInternals)
         y,
       };
 
-      node[zSymbol] = z;
+      node[internalsSymbol].z = z;
 
       if (parentNodes[node.id]) {
-        node[isParentSymbol] = true;
+        node[internalsSymbol].isParent = true;
       }
     }
   });

--- a/src/store/utils.ts
+++ b/src/store/utils.ts
@@ -1,7 +1,7 @@
 import { zoomIdentity } from 'd3-zoom';
 import { GetState, SetState } from 'zustand';
 
-import { isNumeric } from '../utils';
+import { handleBoundsSymbol, isNumeric, isParentSymbol, zSymbol } from '../utils';
 import { getD3Transition, getRectOfNodes, getTransformForBounds } from '../utils/graph';
 import {
   Edge,
@@ -30,7 +30,7 @@ function calculateXYZPosition(
   return calculateXYZPosition(parentNode, nodeInternals, parentNodes, {
     x: (result.x ?? 0) + (parentNode.position?.x ?? 0),
     y: (result.y ?? 0) + (parentNode.position?.y ?? 0),
-    z: (parentNode.z ?? 0) > (result.z ?? 0) ? parentNode.z ?? 0 : result.z ?? 0,
+    z: (parentNode[zSymbol] ?? 0) > (result.z ?? 0) ? parentNode[zSymbol] ?? 0 : result.z ?? 0,
   });
 }
 
@@ -45,18 +45,28 @@ export function createNodeInternals(nodes: Node[], nodeInternals: NodeInternals)
     const internals: Node = {
       width: currInternals?.width,
       height: currInternals?.height,
-      handleBounds: currInternals?.handleBounds,
       ...node,
       positionAbsolute: {
         x: node.position.x,
         y: node.position.y,
       },
-      z,
     };
+
     if (node.parentNode) {
       internals.parentNode = node.parentNode;
       parentNodes[node.parentNode] = true;
     }
+
+    Object.defineProperty(internals, handleBoundsSymbol, {
+      enumerable: false,
+      value: currInternals?.[handleBoundsSymbol],
+    });
+
+    Object.defineProperty(internals, zSymbol, {
+      enumerable: false,
+      value: z,
+    });
+
     nextNodeInternals.set(node.id, internals);
   });
 
@@ -68,7 +78,7 @@ export function createNodeInternals(nodes: Node[], nodeInternals: NodeInternals)
     if (node.parentNode || parentNodes[node.id]) {
       const { x, y, z } = calculateXYZPosition(node, nextNodeInternals, parentNodes, {
         ...node.position,
-        z: node.z ?? 0,
+        z: node[zSymbol] ?? 0,
       });
 
       node.positionAbsolute = {
@@ -76,10 +86,10 @@ export function createNodeInternals(nodes: Node[], nodeInternals: NodeInternals)
         y,
       };
 
-      node.z = z;
+      node[zSymbol] = z;
 
       if (parentNodes[node.id]) {
-        node.isParent = true;
+        node[isParentSymbol] = true;
       }
     }
   });

--- a/src/types/nodes.ts
+++ b/src/types/nodes.ts
@@ -2,6 +2,7 @@ import { CSSProperties, MouseEvent as ReactMouseEvent } from 'react';
 
 import { XYPosition, Position, CoordinateExtent } from './utils';
 import { HandleElement } from './handles';
+import { handleBoundsSymbol, isParentSymbol, zSymbol } from '../utils';
 
 // interface for the user node items
 export interface Node<T = any> {
@@ -28,9 +29,9 @@ export interface Node<T = any> {
 
   // only used internally
   positionAbsolute?: XYPosition;
-  z?: number;
-  handleBounds?: NodeHandleBounds;
-  isParent?: boolean;
+  [zSymbol]?: number;
+  [handleBoundsSymbol]?: NodeHandleBounds;
+  [isParentSymbol]?: boolean;
 }
 
 // props that get passed to a custom node

--- a/src/types/nodes.ts
+++ b/src/types/nodes.ts
@@ -26,9 +26,9 @@ export interface Node<T = any> {
   zIndex?: number;
   extent?: 'parent' | CoordinateExtent;
   expandParent?: boolean;
+  positionAbsolute?: XYPosition;
 
   // only used internally
-  positionAbsolute?: XYPosition;
   [zSymbol]?: number;
   [handleBoundsSymbol]?: NodeHandleBounds;
   [isParentSymbol]?: boolean;

--- a/src/types/nodes.ts
+++ b/src/types/nodes.ts
@@ -2,7 +2,7 @@ import { CSSProperties, MouseEvent as ReactMouseEvent } from 'react';
 
 import { XYPosition, Position, CoordinateExtent } from './utils';
 import { HandleElement } from './handles';
-import { handleBoundsSymbol, isParentSymbol, zSymbol } from '../utils';
+import { internalsSymbol } from '../utils';
 
 // interface for the user node items
 export interface Node<T = any> {
@@ -29,9 +29,11 @@ export interface Node<T = any> {
   positionAbsolute?: XYPosition;
 
   // only used internally
-  [zSymbol]?: number;
-  [handleBoundsSymbol]?: NodeHandleBounds;
-  [isParentSymbol]?: boolean;
+  [internalsSymbol]: {
+    z?: number;
+    handleBounds?: NodeHandleBounds;
+    isParent?: boolean;
+  };
 }
 
 // props that get passed to a custom node

--- a/src/types/nodes.ts
+++ b/src/types/nodes.ts
@@ -29,7 +29,7 @@ export interface Node<T = any> {
   positionAbsolute?: XYPosition;
 
   // only used internally
-  [internalsSymbol]: {
+  [internalsSymbol]?: {
     z?: number;
     handleBounds?: NodeHandleBounds;
     isParent?: boolean;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -41,6 +41,6 @@ export const getBoundsofRects = (rect1: Rect, rect2: Rect): Rect =>
 
 export const isNumeric = (n: any): n is number => !isNaN(n) && isFinite(n);
 
-export const handleBoundsSymbol = Symbol('handleBound');
+export const handleBoundsSymbol = Symbol('handleBounds');
 export const zSymbol = Symbol('z');
 export const isParentSymbol = Symbol('isParent');

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -40,3 +40,7 @@ export const getBoundsofRects = (rect1: Rect, rect2: Rect): Rect =>
   boxToRect(getBoundsOfBoxes(rectToBox(rect1), rectToBox(rect2)));
 
 export const isNumeric = (n: any): n is number => !isNaN(n) && isFinite(n);
+
+export const handleBoundsSymbol = Symbol('handleBound');
+export const zSymbol = Symbol('z');
+export const isParentSymbol = Symbol('isParent');

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -41,6 +41,4 @@ export const getBoundsofRects = (rect1: Rect, rect2: Rect): Rect =>
 
 export const isNumeric = (n: any): n is number => !isNaN(n) && isFinite(n);
 
-export const handleBoundsSymbol = Symbol('handleBounds');
-export const zSymbol = Symbol('z');
-export const isParentSymbol = Symbol('isParent');
+export const internalsSymbol = Symbol('internals');


### PR DESCRIPTION
This PR introduces non-enumarable props for the internals: `handleBounds`, `z` and `isParent` so that they don't get exposed to user land. 