### PR TITLE
fix: update marker types to EdgeMarkerType

### DIFF
--- a/src/types/edges.ts
+++ b/src/types/edges.ts
@@ -59,8 +59,8 @@ export interface EdgeProps<T = any> {
   data?: T;
   sourceHandleId?: string | null;
   targetHandleId?: string | null;
-  markerStart?: string;
-  markerEnd?: string;
+  markerStart?: EdgeMarkerType;
+  markerEnd?: EdgeMarkerType;
   curvature?: number;
 }
 


### PR DESCRIPTION
Signed-off-by: Yue Yang <g1enyy0ung@gmail.com>

As the title. A tiny fix that update `markerStart` and `markerEnd` to `EdgeMarkerType` in `EdgeProps`.