### PR TITLE
fix(validation): Remove css-classes if mouse moves directly to different handle.

### DIFF
--- a/src/components/Handle/handler.ts
+++ b/src/components/Handle/handler.ts
@@ -153,6 +153,7 @@ export function handleMouseDown({
     }
 
     if (connection.source !== connection.target && elementBelow) {
+      resetRecentHandle(recentHoveredHandle);
       recentHoveredHandle = elementBelow;
       elementBelow.classList.add('react-flow__handle-connecting');
       elementBelow.classList.toggle('react-flow__handle-valid', isValid);


### PR DESCRIPTION
If two handles are next to each other or overlap it is possible for the
mouse-cursor to move from one handle to the other without a
mouse-move-event being fired where isHoveringHandle is false.

Thus, the valid and connecting css-classes were not removed from the
handle.

This commit fixes this.

To reproduce you can rearrange the nodes in the validation example like so:
![image](https://user-images.githubusercontent.com/61547179/181476807-737031f9-022e-458d-8ced-2715bb33631e.png)
And then drag a connection from the left node across the three overlapping handles.