### PR TITLE
Skip `onNodesChange` when it's `forceUpdate` in `updateNodeDimensions`

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -77,11 +77,13 @@ const createStore = () =>
               ...dimensions,
             });
 
-            res.push({
-              id: node.id,
-              type: 'dimensions',
-              dimensions,
-            });
+            if (!update.forceUpdate) {
+              res.push({
+                id: node.id,
+                type: 'dimensions',
+                dimensions,
+              });
+            }
           }
         }
 


### PR DESCRIPTION
I think it should only emit `'dimensions'` changes to `onNodesChange` when it's not `forceUpdate` from within `updateNodeDimensions`.

This is an attempt to fix #2405.
