### PR TITLE
Snap node to grid relative to 0,0 instead start position of node

### DIFF
--- a/src/hooks/useDrag/index.ts
+++ b/src/hooks/useDrag/index.ts
@@ -96,14 +96,14 @@ function useDrag({
             }
           })
           .on('drag', (event: UseDragEvent) => {
-            const { updateNodePositions, nodeInternals, nodeExtent, onNodeDrag, onSelectionDrag } = store.getState();
+            const { updateNodePositions, snapToGrid, snapGrid, nodeInternals, nodeExtent, onNodeDrag, onSelectionDrag } = store.getState();
             const pointerPos = getPointerPosition(event);
 
             // skip events without movement
             if ((lastPos.current.x !== pointerPos.x || lastPos.current.y !== pointerPos.y) && dragItems.current) {
               lastPos.current = pointerPos;
               dragItems.current = dragItems.current.map((n) =>
-                updatePosition(n, pointerPos, nodeInternals, nodeExtent)
+                updatePosition(n, pointerPos, snapToGrid, snapGrid, nodeInternals, nodeExtent)
               );
 
               const onDrag = nodeId ? onNodeDrag : wrapSelectionDragFunc(onSelectionDrag);

--- a/src/hooks/useDrag/utils.ts
+++ b/src/hooks/useDrag/utils.ts
@@ -59,11 +59,18 @@ export function getDragItems(nodeInternals: NodeInternals, mousePos: XYPosition,
 export function updatePosition(
   dragItem: NodeDragItem,
   mousePos: XYPosition,
+  snapToGrid: boolean,
+  [snapX, snapY]: [number, number],
   nodeInternals: NodeInternals,
   nodeExtent?: CoordinateExtent
 ): NodeDragItem {
   let currentExtent = dragItem.extent || nodeExtent;
   const nextPosition = { x: mousePos.x - dragItem.distance.x, y: mousePos.y - dragItem.distance.y };
+  if (snapToGrid) {
+    nextPosition.x = snapX * Math.round(nextPosition.x / snapX)
+    nextPosition.y = snapY * Math.round(nextPosition.y / snapY)
+  }
+
 
   if (dragItem.extent === 'parent') {
     if (dragItem.parentNode && dragItem.width && dragItem.height) {


### PR DESCRIPTION
I have an app where the user is able to toggle snapping and noticed some potentially undesirable behaviour. With the current implementation snapping is relative to the start position of the node. I think it makes more sense to snap relative to the centre point of the diagram so when snapping is enabled nodes can be neatly aligned relative to each other.

A quick example, let's say a diagram has a `gridSize=[10, 10]`. With snapping disabled `snapToGrid={false}` the user moves a node to `[7, 7]`. Then the user enables snapping `snapToGrid={true}`. With the current implementation when the user moves the same node it will snap to `[17, 17]`, `[27, 27]` and so on. I think it makes more sense the node would snap to `[10, 10]`, `[20, 20]` or `[30, 30]`.

My proposed code changes fix this though it's a quick solution but I'm keen to rethink how to implement this if the maintainers of this library think this is a good change 🙂