### PR TITLE
Use event.composedPath for getting event target (keydown shadow DOM fix)

### DIFF
--- a/src/hooks/useKeyPress.ts
+++ b/src/hooks/useKeyPress.ts
@@ -108,7 +108,7 @@ function useKeyOrCode(eventCode: string, keysToWatch: KeyCode): KeyOrCode {
 }
 
 function isInputDOMNode(event: KeyboardEvent): boolean {
-  const target = event.target as HTMLElement;
+  const target = event.composedPath()[0] as HTMLElement;
 
   return ['INPUT', 'SELECT', 'TEXTAREA'].includes(target?.nodeName) || target?.hasAttribute('contenteditable');
 }


### PR DESCRIPTION
This PR fixes a problem where keystrokes are not being registered when originating from shadow DOM inputs. Current react-flow implementation attaches a global event listener for `keydown` event and calls `preventDefault()` on it if the following 2 conditions are met:
1. The key name is registered (using props like `deleteKeyCode`, `multiSelectionKeyCode` etc.)
2. **`isInputDOMNode` returns true** 

[This article ](https://tinytip.co/tips/js-event-composed-path/)explains why the current implementation of `isInputDOMNode` doesn't work as well as shows a solution which is used in this PR

Reproducible demo sandbox: https://codesandbox.io/s/react-flow-with-shadow-dom-lymfwm?file=/index.js

