### PR TITLE
fix: (example) Make the newly added node position `more accurate` in DragNDrop example

### DIFF
--- a/example/src/DragNDrop/Sidebar.tsx
+++ b/example/src/DragNDrop/Sidebar.tsx
@@ -1,7 +1,16 @@
 import React, { DragEvent } from 'react';
 
 const onDragStart = (event: DragEvent, nodeType: string) => {
-  event.dataTransfer.setData('application/reactflow', nodeType);
+  const eventX = event.clientX || event.pageX;
+  const eventY = event.clientY || event.pageY;
+  const boundingClientRect = (event.target as HTMLElement).getBoundingClientRect();
+  const offsetX = boundingClientRect.x || boundingClientRect.left;
+  const offsetY = boundingClientRect.y || boundingClientRect.top;
+
+  event.dataTransfer.setData('application/reactflow', JSON.stringify({
+    nodeType,
+    delta: { x: eventX - offsetX, y: eventY - offsetY }
+  }));
   event.dataTransfer.effectAllowed = 'move';
 };
 

--- a/example/src/DragNDrop/index.tsx
+++ b/example/src/DragNDrop/index.tsx
@@ -37,8 +37,8 @@ const DnDFlow = () => {
     event.preventDefault();
 
     if (reactFlowInstance) {
-      const type = event.dataTransfer.getData('application/reactflow');
-      const position = reactFlowInstance.project({ x: event.clientX, y: event.clientY - 40 });
+      const { nodeType: type, delta } = JSON.parse(event.dataTransfer.getData('application/reactflow'));
+      const position = reactFlowInstance.project({ x: event.clientX - delta.x, y: event.clientY - 40 - delta.y });
       const newNode: Node = {
         id: getId(),
         type,


### PR DESCRIPTION
In DragNDrop example as mentioned above, nodes are added to where the mouse is released, however,  we are able to drag from anywhere in the sidebar node, causing the position of the added node to be visually biased. The solution is to record the offset of the drag point from sidebar node when dragging, and apply this offset when dropped. 