### PR TITLE
fix(examples): extra react imports removed

### DIFF
--- a/examples/vite-app/src/examples/ControlledUncontrolled/index.tsx
+++ b/examples/vite-app/src/examples/ControlledUncontrolled/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import ReactFlow, {
   useReactFlow,
   Node,

--- a/examples/vite-app/src/examples/DefaultNodes/index.tsx
+++ b/examples/vite-app/src/examples/DefaultNodes/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import ReactFlow, { useReactFlow, Node, Edge, ReactFlowProvider, Background, BackgroundVariant } from 'reactflow';
 
 const defaultNodes: Node[] = [

--- a/examples/vite-app/src/examples/EdgeRouting/index.tsx
+++ b/examples/vite-app/src/examples/EdgeRouting/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import ReactFlow, { Node, Edge, Position, MarkerType } from 'reactflow';
 
 const nodes: Node[] = [

--- a/examples/vite-app/src/examples/Provider/Sidebar.tsx
+++ b/examples/vite-app/src/examples/Provider/Sidebar.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useStore, useStoreApi } from 'reactflow';
 
 import styles from './provider.module.css';

--- a/examples/vite-app/src/examples/UseKeyPress/index.tsx
+++ b/examples/vite-app/src/examples/UseKeyPress/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useKeyPress } from 'reactflow';
 
 const UseKeyPressComponent = () => {


### PR DESCRIPTION
Extra `import React from 'react'`s removed from examples. Some imports remained in the files after switching to Vite, despite the fact that Vite will handle it automatically and there is no need to import them for our JSX.