### PR TITLE
Add css files as sideEffects

### DIFF
--- a/packages/reactflow/package.json
+++ b/packages/reactflow/package.json
@@ -17,7 +17,7 @@
   "main": "dist/umd/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",
-  "sideEffects": false,
+  "sideEffects": ["*.css"],
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
According to the webpack docs about tree shaking, css files should be considered as side effects: https://webpack.js.org/guides/tree-shaking/#:~:text=**/*.css.-,Tip,-Note%20that%20any

This should fix #2477.
