### PR TITLE
Restrict edge animation to visual stroke.

### DIFF
--- a/packages/core/src/styles/init.css
+++ b/packages/core/src/styles/init.css
@@ -51,7 +51,7 @@
   pointer-events: visibleStroke;
   cursor: pointer;
 
-  &.animated path {
+  &.animated path.react-flow__edge-path {
     stroke-dasharray: 5;
     animation: dashdraw 0.5s linear infinite;
   }


### PR DESCRIPTION
The `stroke-dasharray` property causes issues when applied to the hidden interactive stroke as documented here https://github.com/wbkd/react-flow/issues/1114#issuecomment-826393588. This restricts the css selector which applies the animation to just the 'real' stroke instead of applying it to both. I haven't had a chance to thoroughly test this, but am creating the PR now to see if I should take a different approach to fixing the problem. 