### PR TITLE
Always elevate 1000 in `zIndex` when node is selected

### DIFF
--- a/.changeset/silly-taxis-drop.md
+++ b/.changeset/silly-taxis-drop.md
@@ -1,0 +1,5 @@
+---
+'@reactflow/core': patch
+---
+
+Core: Always elevate zIndex when node is selected

--- a/packages/core/src/store/utils.ts
+++ b/packages/core/src/store/utils.ts
@@ -39,7 +39,7 @@ export function createNodeInternals(nodes: Node[], nodeInternals: NodeInternals)
   const parentNodes: ParentNodes = {};
 
   nodes.forEach((node) => {
-    const z = isNumeric(node.zIndex) ? node.zIndex : node.selected ? 1000 : 0;
+    const z = (isNumeric(node.zIndex) ? node.zIndex : 0) + (node.selected ? 1000 : 0);
     const currInternals = nodeInternals.get(node.id);
 
     const internals: Node = {


### PR DESCRIPTION
Instead of only elevating when `zIndex` is unset