### PR TITLE
ref: stop using try..catch as control flow in Wrapper

### DIFF
--- a/packages/core/src/container/ReactFlow/Wrapper.tsx
+++ b/packages/core/src/container/ReactFlow/Wrapper.tsx
@@ -1,18 +1,10 @@
-import type { FC, PropsWithChildren } from 'react';
+import { FC, PropsWithChildren, useContext } from 'react';
 
-import { useStoreApi } from '../../hooks/useStore';
+import StoreContext from '../../contexts/RFStoreContext';
 import ReactFlowProvider from '../../components/ReactFlowProvider';
 
 const Wrapper: FC<PropsWithChildren> = ({ children }) => {
-  let isWrapped = true;
-
-  try {
-    useStoreApi();
-  } catch (e) {
-    isWrapped = false;
-  }
-
-  if (isWrapped) {
+  if (useContext(StoreContext)) {
     // we need to wrap it with a fragment because it's not allowed for children to be a ReactNode
     // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18051
     return <>{children}</>;


### PR DESCRIPTION
Previously, Wrapper used try..catch around a call to useStoreApi to check whether there was an available StoreContext, instead of simply using useContext and checking the value. This leads to poor developer experience when using the devtools feature "pause on caught exceptions" as it causes the devtools to break on every render of a Wrapper that is not within a StoreContext provider. The catch is also universal, meaning that it could catch a completely unrelated error and happily keep going instead of crashing which is undesirable.

This commit changes this try..catch into a simple call to useContext to check if a StoreContext is available.