### PR TITLE
fix: check whether property is valid or not correctly at isRectObject

### DIFF
--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -53,7 +53,7 @@ export const getOverlappingArea = (rectA: Rect, rectB: Rect): number => {
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const isRectObject = (obj: any): obj is Rect => obj.width !== undefined && obj.height !== undefined && obj.x !== undefined && obj.y !== undefined;
+export const isRectObject = (obj: any): obj is Rect => obj.width != null && obj.height != null && obj.x != null && obj.y != null;
 
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
 export const isNumeric = (n: any): n is number => !isNaN(n) && isFinite(n);

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -53,7 +53,7 @@ export const getOverlappingArea = (rectA: Rect, rectB: Rect): number => {
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const isRectObject = (obj: any): obj is Rect => !!obj.width && !!obj.height && !!obj.x && !!obj.y;
+export const isRectObject = (obj: any): obj is Rect => obj.width !== undefined && obj.height !== undefined && obj.x !== undefined && obj.y !== undefined;
 
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
 export const isNumeric = (n: any): n is number => !isNaN(n) && isFinite(n);


### PR DESCRIPTION
when i use `isNodeIntersecting`, intermittently `TypeError: Cannot read properties of undefined (reading 'positionAbsolute')` exception is thrown.

so I've been trying to debug why this is happening.

i found that this error occurs when i pass an object typed `Rect` to first parameter of `isNodeIntersecting`(=`nodeOrRect`).

`isRectObject` is called in `isNodeIntersecting` to know whether the first parameter is Node or Rect.

the return value of `isRectObject` is below.
```ts
!!obj.width && !!obj.height && !!obj.x && !!obj.y
```

when Rect.x or Rect.y equals 0(zero), the condition of `isRectObject` becomes false. it is wrong.

so i modified this condition to check correctly object's properties are whether `undefined`, `null` or not.