### PR TITLE
Invalidate a Node trying to connect itself with the same handle

### DIFF
--- a/packages/core/src/components/Handle/handler.ts
+++ b/packages/core/src/components/Handle/handler.ts
@@ -60,7 +60,7 @@ export function checkElementBelowIsValid(
     const isValid =
       connectionMode === ConnectionMode.Strict
         ? (isTarget && elementBelowIsSource) || (!isTarget && elementBelowIsTarget)
-        : true;
+        : elementBelowNodeId !== nodeId || elementBelowHandleId !== handleId;
 
     if (isValid) {
       result.isValid = isValidConnection(connection);

--- a/packages/minimap/CHANGELOG.md
+++ b/packages/minimap/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- [`7ece618d`](https://github.com/wbkd/react-flow/commit/7ece618d94b76183c1ecd45b16f6ab168168351b) Thanks [@](https://github.com/lounsbrough)! - Fix minimap node position
+- [`7ece618d`](https://github.com/wbkd/react-flow/commit/7ece618d94b76183c1ecd45b16f6ab168168351b) Thanks [@lounsbrough](https://github.com/lounsbrough)! - Fix minimap node position
 
 ## 11.2.1
 

--- a/packages/reactflow/CHANGELOG.md
+++ b/packages/reactflow/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- [`7ece618d`](https://github.com/wbkd/react-flow/commit/7ece618d94b76183c1ecd45b16f6ab168168351b) Thanks [@](https://github.com/lounsbrough)! - Fix minimap node position
+- [`7ece618d`](https://github.com/wbkd/react-flow/commit/7ece618d94b76183c1ecd45b16f6ab168168351b) Thanks [@lounsbrough](https://github.com/lounsbrough)! - Fix minimap node position
 
 - Updated dependencies [[`7ece618d`](https://github.com/wbkd/react-flow/commit/7ece618d94b76183c1ecd45b16f6ab168168351b)]:
   - @reactflow/minimap@11.2.2


### PR DESCRIPTION
(in my opinion) A node shouldn't connect to itself on the same handle, and it becomes more obvious when one is trying to perform "click and connect" in the "loose" mode.

It could also be written as `!(elementBelowNodeId === nodeId && elementBelowHandleId === handleId)` depending preference, either way makes sense to me.