### PR TITLE
Add generic support for the type property on the Node type

### DIFF
--- a/packages/core/src/types/nodes.ts
+++ b/packages/core/src/types/nodes.ts
@@ -5,11 +5,11 @@ import { internalsSymbol } from '../utils';
 import type { XYPosition, Position, CoordinateExtent, HandleElement } from '.';
 
 // interface for the user node items
-export type Node<T = any> = {
+export type Node<T = any, U extends string | undefined = string | undefined> = {
   id: string;
   position: XYPosition;
   data: T;
-  type?: string;
+  type: U;
   style?: CSSProperties;
   className?: string;
   sourcePosition?: Position;


### PR DESCRIPTION
I have added custom Node Types in my codebase and it could be great if I could set the type property of the Node type to an Enum or string literal. In order to support that, I have added another Generic to the Node type and then set the type property to exactly that generic type. Note that, the default of that generic type is the same as the current type is, so this change should be fully backwards compatible.

Also when making this change, I was wondering why type can be undefined?

