### PR TITLE
Feat: Add NodeResizer package

### DIFF
--- a/.changeset/nasty-suns-hear.md
+++ b/.changeset/nasty-suns-hear.md
@@ -1,0 +1,5 @@
+---
+'@reactflow/node-toolbar': patch
+---
+
+Get nodeId from React Flow context if it is not passed explicitly as prop

--- a/.changeset/smooth-swans-exist.md
+++ b/.changeset/smooth-swans-exist.md
@@ -1,0 +1,5 @@
+---
+'@reactflow/core': patch
+---
+
+Export the useNodeId hook, refactor how changes are applied and create a helper function

--- a/.changeset/twelve-icons-tan.md
+++ b/.changeset/twelve-icons-tan.md
@@ -1,0 +1,5 @@
+---
+'@reactflow/node-resizer': major
+---
+
+Add a node resizer component that can be used to resize a custom node

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ function Flow() {
     </ReactFlow>
   );
 }
+
 export default Flow;
 ```
 

--- a/examples/vite-app/package.json
+++ b/examples/vite-app/package.json
@@ -13,6 +13,7 @@
     "test-e2e": "start-server-and-test 'pnpm serve' http-get://localhost:3000 'pnpm test-e2e-cypress'"
   },
   "dependencies": {
+    "@reactflow/node-resizer": "workspace:^0.0.0",
     "classcat": "^5.0.3",
     "dagre": "^0.8.5",
     "localforage": "^1.10.0",

--- a/examples/vite-app/src/App/index.tsx
+++ b/examples/vite-app/src/App/index.tsx
@@ -20,6 +20,7 @@ import Intersection from '../examples/Intersection';
 import Layouting from '../examples/Layouting';
 import MultiFlows from '../examples/MultiFlows';
 import NestedNodes from '../examples/NestedNodes';
+import NodeResizer from '../examples/NodeResizer';
 import NodeTypeChange from '../examples/NodeTypeChange';
 import NodeTypesObjectChange from '../examples/NodeTypesObjectChange';
 import Overview from '../examples/Overview';
@@ -173,6 +174,11 @@ const routes: IRoute[] = [
     name: 'NodeToolbar',
     path: '/node-toolbar',
     component: NodeToolbar,
+  },
+  {
+    name: 'NodeResizer',
+    path: '/node-resizer',
+    component: NodeResizer,
   },
   {
     name: 'Overview',

--- a/examples/vite-app/src/examples/Basic/index.tsx
+++ b/examples/vite-app/src/examples/Basic/index.tsx
@@ -94,7 +94,7 @@ const BasicFlow = () => {
       fitView
       defaultEdgeOptions={defaultEdgeOptions}
       selectNodesOnDrag={false}
-      nodeOrigin={nodeOrigin}
+      // nodeOrigin={nodeOrigin}
     >
       <Background variant={BackgroundVariant.Dots} />
       <MiniMap />

--- a/examples/vite-app/src/examples/NodeResizer/CustomNode.tsx
+++ b/examples/vite-app/src/examples/NodeResizer/CustomNode.tsx
@@ -1,0 +1,18 @@
+import { memo, FC } from 'react';
+import { Handle, Position, NodeProps } from 'reactflow';
+
+import { NodeResizer } from '@reactflow/node-resizer';
+
+const ColorSelectorNode: FC<NodeProps> = ({ id, data }) => {
+  return (
+    <>
+      <Handle type="target" position={Position.Left} />
+      <div>{data.label}</div>
+      <Handle type="source" position={Position.Right} />
+
+      <NodeResizer nodeId={id} />
+    </>
+  );
+};
+
+export default memo(ColorSelectorNode);

--- a/examples/vite-app/src/examples/NodeResizer/CustomResizer.tsx
+++ b/examples/vite-app/src/examples/NodeResizer/CustomResizer.tsx
@@ -13,7 +13,7 @@ const controlStyle = {
 const CustomNode: FC<NodeProps> = ({ id, data }) => {
   return (
     <>
-      <NodeResizeControl nodeId={id} style={controlStyle}>
+      <NodeResizeControl style={controlStyle}>
         <ResizeIcon />
       </NodeResizeControl>
 

--- a/examples/vite-app/src/examples/NodeResizer/CustomResizer.tsx
+++ b/examples/vite-app/src/examples/NodeResizer/CustomResizer.tsx
@@ -1,0 +1,27 @@
+import { memo, FC, CSSProperties } from 'react';
+import { Handle, Position, NodeProps } from 'reactflow';
+
+import { NodeResizer, NodeResizeControl } from '@reactflow/node-resizer';
+import '@reactflow/node-resizer/dist/style.css';
+import ResizeIcon from './ResizeIcon';
+
+const controlStyle = {
+  background: 'transparent',
+  border: 'none',
+};
+
+const CustomNode: FC<NodeProps> = ({ id, data }) => {
+  return (
+    <>
+      <NodeResizeControl nodeId={id} style={controlStyle}>
+        <ResizeIcon />
+      </NodeResizeControl>
+
+      <Handle type="target" position={Position.Left} />
+      <div>{data.label}</div>
+      <Handle type="source" position={Position.Right} />
+    </>
+  );
+};
+
+export default memo(CustomNode);

--- a/examples/vite-app/src/examples/NodeResizer/CustomResizer2.tsx
+++ b/examples/vite-app/src/examples/NodeResizer/CustomResizer2.tsx
@@ -1,0 +1,19 @@
+import { memo, FC } from 'react';
+import { Handle, Position, NodeProps } from 'reactflow';
+
+import { NodeResizer, NodeResizeControl } from '@reactflow/node-resizer';
+import '@reactflow/node-resizer/dist/style.css';
+
+const CustomNode: FC<NodeProps> = ({ id, data }) => {
+  return (
+    <>
+      <NodeResizeControl nodeId={id} position="top" />
+      <NodeResizeControl nodeId={id} position="bottom" />
+      <Handle type="target" position={Position.Left} />
+      <div>{data.label}</div>
+      <Handle type="source" position={Position.Right} />
+    </>
+  );
+};
+
+export default memo(CustomNode);

--- a/examples/vite-app/src/examples/NodeResizer/CustomResizer2.tsx
+++ b/examples/vite-app/src/examples/NodeResizer/CustomResizer2.tsx
@@ -7,10 +7,10 @@ import '@reactflow/node-resizer/dist/style.css';
 const CustomNode: FC<NodeProps> = ({ id, data }) => {
   return (
     <>
-      <NodeResizeControl nodeId={id} position="top" />
-      <NodeResizeControl nodeId={id} position="bottom" />
+      <NodeResizeControl color="red" position="top" />
+      <NodeResizeControl color="red" position="bottom" />
       <Handle type="target" position={Position.Left} />
-      <div>{data.label}</div>
+      <div style={{ padding: 10 }}>{data.label}</div>
       <Handle type="source" position={Position.Right} />
     </>
   );

--- a/examples/vite-app/src/examples/NodeResizer/NodeResizerNode.tsx
+++ b/examples/vite-app/src/examples/NodeResizer/NodeResizerNode.tsx
@@ -2,17 +2,17 @@ import { memo, FC } from 'react';
 import { Handle, Position, NodeProps } from 'reactflow';
 
 import { NodeResizer } from '@reactflow/node-resizer';
+import '@reactflow/node-resizer/dist/style.css';
 
-const ColorSelectorNode: FC<NodeProps> = ({ id, data }) => {
+const CustomNode: FC<NodeProps> = ({ id, data }) => {
   return (
     <>
+      <NodeResizer nodeId={id} />
       <Handle type="target" position={Position.Left} />
       <div>{data.label}</div>
       <Handle type="source" position={Position.Right} />
-
-      <NodeResizer nodeId={id} />
     </>
   );
 };
 
-export default memo(ColorSelectorNode);
+export default memo(CustomNode);

--- a/examples/vite-app/src/examples/NodeResizer/NodeResizerNode.tsx
+++ b/examples/vite-app/src/examples/NodeResizer/NodeResizerNode.tsx
@@ -4,10 +4,10 @@ import { Handle, Position, NodeProps } from 'reactflow';
 import { NodeResizer } from '@reactflow/node-resizer';
 import '@reactflow/node-resizer/dist/style.css';
 
-const CustomNode: FC<NodeProps> = ({ id, data }) => {
+const CustomNode: FC<NodeProps> = ({ id, data, selected }) => {
   return (
     <>
-      <NodeResizer nodeId={id} />
+      <NodeResizer isVisible={selected} />
       <Handle type="target" position={Position.Left} />
       <div>{data.label}</div>
       <Handle type="source" position={Position.Right} />

--- a/examples/vite-app/src/examples/NodeResizer/ResizeIcon.tsx
+++ b/examples/vite-app/src/examples/NodeResizer/ResizeIcon.tsx
@@ -1,0 +1,24 @@
+function ResizeIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="8"
+      height="8"
+      viewBox="0 0 24 24"
+      stroke-width="2"
+      stroke="currentColor"
+      fill="none"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      style={{ position: 'absolute', right: 2, bottom: 2 }}
+    >
+      <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+      <polyline points="16 20 20 20 20 16" />
+      <line x1="14" y1="14" x2="20" y2="20" />
+      <polyline points="8 4 4 4 4 8" />
+      <line x1="4" y1="4" x2="10" y2="10" />
+    </svg>
+  );
+}
+
+export default ResizeIcon;

--- a/examples/vite-app/src/examples/NodeResizer/ResizeIcon.tsx
+++ b/examples/vite-app/src/examples/NodeResizer/ResizeIcon.tsx
@@ -5,11 +5,11 @@ function ResizeIcon() {
       width="8"
       height="8"
       viewBox="0 0 24 24"
-      stroke-width="2"
+      strokeWidth="2"
       stroke="currentColor"
       fill="none"
-      stroke-linecap="round"
-      stroke-linejoin="round"
+      strokeLinecap="round"
+      strokeLinejoin="round"
       style={{ position: 'absolute', right: 2, bottom: 2 }}
     >
       <path stroke="none" d="M0 0h24v24H0z" fill="none" />

--- a/examples/vite-app/src/examples/NodeResizer/index.tsx
+++ b/examples/vite-app/src/examples/NodeResizer/index.tsx
@@ -1,10 +1,14 @@
 import { useCallback } from 'react';
 import ReactFlow, { Controls, addEdge, Position, Connection, useNodesState, useEdgesState } from 'reactflow';
 
-import CustomNode from './CustomNode';
+import NodeResizerNode from './NodeResizerNode';
+import CustomResizer from './CustomResizer';
+import CustomResizer2 from './CustomResizer2';
 
 const nodeTypes = {
-  custom: CustomNode,
+  resizer: NodeResizerNode,
+  customResizer: CustomResizer,
+  customResizer2: CustomResizer2,
 };
 
 const initialEdges = [
@@ -25,10 +29,24 @@ const initialNodes = [
   },
   {
     id: '2',
-    type: 'custom',
-    data: { label: 'resize me!' },
+    type: 'resizer',
+    data: { label: 'default resizer' },
     position: { x: 250, y: 0 },
-    style: { padding: 10, border: '1px solid #222' },
+    style: { padding: 10, border: '1px solid #222', fontSize: 10 },
+  },
+  {
+    id: '3',
+    type: 'customResizer',
+    data: { label: 'resize control with child component' },
+    position: { x: 250, y: 150 },
+    style: { padding: 10, border: '1px solid #222', fontSize: 10, width: 100 },
+  },
+  {
+    id: '4',
+    type: 'customResizer2',
+    data: { label: 'resize controls' },
+    position: { x: 100, y: 150 },
+    style: { padding: 10, border: '1px solid #222', fontSize: 10 },
   },
 ];
 

--- a/examples/vite-app/src/examples/NodeResizer/index.tsx
+++ b/examples/vite-app/src/examples/NodeResizer/index.tsx
@@ -1,0 +1,62 @@
+import { useCallback } from 'react';
+import ReactFlow, { Controls, addEdge, Position, Connection, useNodesState, useEdgesState } from 'reactflow';
+
+import CustomNode from './CustomNode';
+
+const nodeTypes = {
+  custom: CustomNode,
+};
+
+const initialEdges = [
+  {
+    id: 'e1-2',
+    source: '1',
+    target: '2',
+  },
+];
+
+const initialNodes = [
+  {
+    id: '1',
+    type: 'input',
+    data: { label: 'An input node' },
+    position: { x: 0, y: 0 },
+    sourcePosition: Position.Right,
+  },
+  {
+    id: '2',
+    type: 'custom',
+    data: { label: 'resize me!' },
+    position: { x: 250, y: 0 },
+    style: { padding: 10, border: '1px solid #222' },
+  },
+];
+
+const CustomNodeFlow = () => {
+  const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
+  const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
+
+  const onConnect = useCallback(
+    (connection: Connection) => setEdges((eds) => addEdge({ ...connection }, eds)),
+    [setEdges]
+  );
+
+  return (
+    <ReactFlow
+      nodes={nodes}
+      edges={edges}
+      onNodesChange={onNodesChange}
+      onEdgesChange={onEdgesChange}
+      onConnect={onConnect}
+      nodeTypes={nodeTypes}
+      snapToGrid={true}
+      fitView
+      minZoom={0.3}
+      maxZoom={2}
+    >
+      <Controls />
+    </ReactFlow>
+  );
+};
+
+export default CustomNodeFlow;

--- a/examples/vite-app/src/examples/NodeResizer/index.tsx
+++ b/examples/vite-app/src/examples/NodeResizer/index.tsx
@@ -1,13 +1,5 @@
 import { useCallback } from 'react';
-import ReactFlow, {
-  Controls,
-  addEdge,
-  Position,
-  Connection,
-  useNodesState,
-  useEdgesState,
-  NodeChange,
-} from 'reactflow';
+import ReactFlow, { Controls, addEdge, Position, Connection, useNodesState, useEdgesState } from 'reactflow';
 
 import CustomNode from './CustomNode';
 
@@ -41,19 +33,12 @@ const initialNodes = [
 ];
 
 const CustomNodeFlow = () => {
-  const [nodes, setNodes, _onNodesChange] = useNodesState(initialNodes);
+  const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
 
   const onConnect = useCallback(
     (connection: Connection) => setEdges((eds) => addEdge({ ...connection }, eds)),
     [setEdges]
-  );
-
-  const onNodesChange = useCallback(
-    (changes: NodeChange[]) => {
-      _onNodesChange(changes);
-    },
-    [_onNodesChange]
   );
 
   return (
@@ -67,6 +52,7 @@ const CustomNodeFlow = () => {
       fitView
       minZoom={0.3}
       maxZoom={2}
+      snapToGrid
     >
       <Controls />
     </ReactFlow>

--- a/examples/vite-app/src/examples/NodeResizer/index.tsx
+++ b/examples/vite-app/src/examples/NodeResizer/index.tsx
@@ -1,5 +1,5 @@
-import { useCallback } from 'react';
-import ReactFlow, { Controls, addEdge, Position, Connection, useNodesState, useEdgesState } from 'reactflow';
+import { CSSProperties, useCallback, useState } from 'react';
+import ReactFlow, { Controls, addEdge, Position, Connection, useNodesState, useEdgesState, Panel } from 'reactflow';
 
 import NodeResizerNode from './NodeResizerNode';
 import CustomResizer from './CustomResizer';
@@ -32,25 +32,40 @@ const initialNodes = [
     type: 'resizer',
     data: { label: 'default resizer' },
     position: { x: 250, y: 0 },
-    style: { padding: 10, border: '1px solid #222', fontSize: 10 },
+    style: {
+      width: 200,
+      height: 150,
+      border: '1px solid #222',
+      fontSize: 10,
+    },
   },
   {
     id: '3',
     type: 'customResizer',
     data: { label: 'resize control with child component' },
     position: { x: 250, y: 150 },
-    style: { padding: 10, border: '1px solid #222', fontSize: 10, width: 100 },
+    style: { border: '1px solid #222', fontSize: 10, width: 100 },
+    parentNode: '2',
   },
   {
     id: '4',
     type: 'customResizer2',
     data: { label: 'resize controls' },
     position: { x: 100, y: 150 },
-    style: { padding: 10, border: '1px solid #222', fontSize: 10 },
+    style: { border: '1px solid #222', fontSize: 10 },
+    parentNode: '2',
+  },
+  {
+    id: '5',
+    type: 'customResizer2',
+    data: { label: 'min width and height' },
+    position: { x: 100, y: 150 },
+    style: { border: '1px solid #222', fontSize: 10 },
   },
 ];
 
 const CustomNodeFlow = () => {
+  const [snapToGrid, setSnapToGrid] = useState(false);
   const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
 
@@ -67,12 +82,14 @@ const CustomNodeFlow = () => {
       onEdgesChange={onEdgesChange}
       onConnect={onConnect}
       nodeTypes={nodeTypes}
-      fitView
-      minZoom={0.3}
-      maxZoom={2}
-      snapToGrid
+      minZoom={-5}
+      maxZoom={5}
+      snapToGrid={snapToGrid}
     >
       <Controls />
+      <Panel position="bottom-right">
+        <button onClick={() => setSnapToGrid(!snapToGrid)}>snapToGrid: {snapToGrid ? 'on' : 'off'}</button>
+      </Panel>
     </ReactFlow>
   );
 };

--- a/examples/vite-app/src/examples/NodeResizer/index.tsx
+++ b/examples/vite-app/src/examples/NodeResizer/index.tsx
@@ -1,5 +1,13 @@
 import { useCallback } from 'react';
-import ReactFlow, { Controls, addEdge, Position, Connection, useNodesState, useEdgesState } from 'reactflow';
+import ReactFlow, {
+  Controls,
+  addEdge,
+  Position,
+  Connection,
+  useNodesState,
+  useEdgesState,
+  NodeChange,
+} from 'reactflow';
 
 import CustomNode from './CustomNode';
 
@@ -33,12 +41,19 @@ const initialNodes = [
 ];
 
 const CustomNodeFlow = () => {
-  const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
+  const [nodes, setNodes, _onNodesChange] = useNodesState(initialNodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
 
   const onConnect = useCallback(
     (connection: Connection) => setEdges((eds) => addEdge({ ...connection }, eds)),
     [setEdges]
+  );
+
+  const onNodesChange = useCallback(
+    (changes: NodeChange[]) => {
+      _onNodesChange(changes);
+    },
+    [_onNodesChange]
   );
 
   return (
@@ -49,7 +64,6 @@ const CustomNodeFlow = () => {
       onEdgesChange={onEdgesChange}
       onConnect={onConnect}
       nodeTypes={nodeTypes}
-      snapToGrid={true}
       fitView
       minZoom={0.3}
       maxZoom={2}

--- a/examples/vite-app/src/examples/NodeToolbar/CustomNode.tsx
+++ b/examples/vite-app/src/examples/NodeToolbar/CustomNode.tsx
@@ -4,7 +4,7 @@ import { Handle, Position, NodeProps, NodeToolbar } from 'reactflow';
 const CustomNode: FC<NodeProps> = ({ id, data }) => {
   return (
     <>
-      <NodeToolbar nodeId={id} isVisible={data.toolbarVisible} position={data.toolbarPosition}>
+      <NodeToolbar isVisible={data.toolbarVisible} position={data.toolbarPosition}>
         <button>delete</button>
         <button>copy</button>
         <button>expand</button>

--- a/packages/core/src/components/Handle/index.tsx
+++ b/packages/core/src/components/Handle/index.tsx
@@ -1,9 +1,9 @@
-import { memo, useContext, HTMLAttributes, forwardRef, MouseEvent as ReactMouseEvent } from 'react';
+import { memo, HTMLAttributes, forwardRef, MouseEvent as ReactMouseEvent } from 'react';
 import cc from 'classcat';
 import shallow from 'zustand/shallow';
 
 import { useStore, useStoreApi } from '../../hooks/useStore';
-import NodeIdContext from '../../contexts/NodeIdContext';
+import { useNodeId } from '../../contexts/NodeIdContext';
 import { checkElementBelowIsValid, handleMouseDown } from './handler';
 import { getHostForElement } from '../../utils';
 import { addEdge } from '../../utils/graph';
@@ -37,7 +37,9 @@ const Handle = forwardRef<HTMLDivElement, HandleComponentProps>(
     ref
   ) => {
     const store = useStoreApi();
-    const nodeId = useContext(NodeIdContext) as string;
+
+    // @fixme: remove type assertion and handle nodeId === null
+    const nodeId = useNodeId() as string;
     const { connectionStartHandle, connectOnClick, noPanClassName } = useStore(selector, shallow);
 
     const handleId = id || null;

--- a/packages/core/src/components/Nodes/NodeResizer.tsx
+++ b/packages/core/src/components/Nodes/NodeResizer.tsx
@@ -1,0 +1,137 @@
+import { useRef, useEffect } from 'react';
+import { drag } from 'd3-drag';
+import { select } from 'd3-selection';
+import type { D3DragEvent, SubjectPosition } from 'd3';
+import { useStoreApi } from '../../hooks/useStore';
+import { Dimensions, Node, XYPosition } from '../../types';
+
+type NodeResizerProps = {
+  nodeId: string;
+};
+
+type ResizeHandleProps = {
+  nodeId: string;
+  invertX?: boolean;
+  invertY?: boolean;
+  enableX?: boolean;
+  enableY?: boolean;
+  top?: number | string;
+  left?: number | string;
+};
+
+type ResizeDragEvent = D3DragEvent<HTMLDivElement, null, SubjectPosition>;
+
+function ResizeHandle({
+  top = 0,
+  left = 0,
+  invertX = false,
+  invertY = false,
+  enableX = false,
+  enableY = false,
+  nodeId,
+}: ResizeHandleProps) {
+  const store = useStoreApi();
+  const resizeHandleRef = useRef<HTMLDivElement>(null);
+  const initialDimensionsRef = useRef<Dimensions & XYPosition>({ width: 0, height: 0, x: 0, y: 0 });
+  const nodeElementRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!resizeHandleRef.current) {
+      return;
+    }
+
+    const selection = select(resizeHandleRef.current);
+    const dragHandler = drag<HTMLDivElement, unknown>()
+      .on('start', () => {
+        const { transform, nodeInternals } = store.getState();
+        const node = nodeInternals.get(nodeId);
+        const nodeElement = document.querySelector(`.react-flow__node[data-id="${nodeId}"]`) as HTMLDivElement;
+        const bbox = nodeElement.getBoundingClientRect();
+        initialDimensionsRef.current = {
+          width: bbox.width / transform[2],
+          height: bbox.height / transform[2],
+          x: node?.position.x || 0,
+          y: node?.position.y || 0,
+        };
+        nodeElementRef.current = nodeElement;
+      })
+      .on('drag', (evt: ResizeDragEvent) => {
+        const { transform, updateNodePositions, nodeInternals } = store.getState();
+
+        const nodeEl = nodeElementRef.current;
+        const node = nodeInternals.get(nodeId);
+
+        if (nodeEl && node) {
+          const moveX = invertX ? -evt.x : evt.x;
+          const moveY = invertY ? -evt.y : evt.y;
+          const distX = enableX ? moveX - evt.subject.x : 0;
+          const distY = enableY ? moveY - evt.subject.y : 0;
+          const dragX = distX / transform[2];
+          const dragY = distY / transform[2];
+
+          const xPos = invertX ? initialDimensionsRef.current.x - dragX : initialDimensionsRef.current.x;
+          const yPos = invertY ? initialDimensionsRef.current.y - dragY : initialDimensionsRef.current.y;
+
+          console.log(dragX);
+
+          nodeEl.style.width = `${initialDimensionsRef.current.width + dragX}px`;
+          nodeEl.style.height = `${initialDimensionsRef.current.height + dragY}px`;
+          nodeEl.style.transform = `translate(${xPos}px, ${yPos}px)`;
+
+          if (invertX || invertY) {
+            const positionUpdate = { x: xPos, y: yPos };
+
+            updateNodePositions(
+              [
+                {
+                  id: nodeId,
+                  position: positionUpdate,
+                  // positionAbsolute: node.positionAbsolute,
+                } as Node,
+              ],
+              true,
+              false
+            );
+          }
+        }
+      });
+
+    selection.call(dragHandler);
+
+    return () => {
+      selection.on('.drag', null);
+    };
+  }, [nodeId]);
+
+  return (
+    <div
+      className="nodrag"
+      ref={resizeHandleRef}
+      style={{
+        position: 'absolute',
+        left,
+        top,
+        width: 10,
+        height: 10,
+        background: 'red',
+        borderRadius: '50%',
+        transform: 'translate(-50%, -50%)',
+      }}
+    />
+  );
+}
+
+export default function NodeResizer({ nodeId }: NodeResizerProps) {
+  return (
+    <>
+      <ResizeHandle nodeId={nodeId} top={0} left={0} enableX enableY invertX invertY />
+      <ResizeHandle nodeId={nodeId} top="50%" left={0} enableX invertX />
+      <ResizeHandle nodeId={nodeId} top="100%" left={0} enableX enableY />
+      <ResizeHandle nodeId={nodeId} top={0} left="50%" enableY invertY />
+      <ResizeHandle nodeId={nodeId} top={0} left="100%" enableX enableY invertY />
+      <ResizeHandle nodeId={nodeId} top="50%" left="100%" enableX />
+      <ResizeHandle nodeId={nodeId} top="100%" left="100%" enableX enableY />
+      <ResizeHandle nodeId={nodeId} top="100%" left="50%" enableY />
+    </>
+  );
+}

--- a/packages/core/src/components/Nodes/wrapNode.tsx
+++ b/packages/core/src/components/Nodes/wrapNode.tsx
@@ -2,8 +2,6 @@ import { useEffect, useRef, memo } from 'react';
 import type { ComponentType, MouseEvent, KeyboardEvent } from 'react';
 import cc from 'classcat';
 
-import NodeResizer from './NodeResizer';
-
 import { useStoreApi } from '../../hooks/useStore';
 import { Provider } from '../../contexts/NodeIdContext';
 import { ARIA_NODE_DESC_KEY } from '../A11yDescriptions';
@@ -220,7 +218,6 @@ export default (NodeComponent: ComponentType<NodeProps>) => {
             zIndex={zIndex}
           />
         </Provider>
-        <NodeResizer nodeId={id} />
       </div>
     );
   };

--- a/packages/core/src/components/Nodes/wrapNode.tsx
+++ b/packages/core/src/components/Nodes/wrapNode.tsx
@@ -2,6 +2,8 @@ import { useEffect, useRef, memo } from 'react';
 import type { ComponentType, MouseEvent, KeyboardEvent } from 'react';
 import cc from 'classcat';
 
+import NodeResizer from './NodeResizer';
+
 import { useStoreApi } from '../../hooks/useStore';
 import { Provider } from '../../contexts/NodeIdContext';
 import { ARIA_NODE_DESC_KEY } from '../A11yDescriptions';
@@ -218,6 +220,7 @@ export default (NodeComponent: ComponentType<NodeProps>) => {
             zIndex={zIndex}
           />
         </Provider>
+        <NodeResizer nodeId={id} />
       </div>
     );
   };

--- a/packages/core/src/container/NodeRenderer/index.tsx
+++ b/packages/core/src/container/NodeRenderer/index.tsx
@@ -57,6 +57,7 @@ const NodeRenderer = (props: NodeRendererProps) => {
         nodeElement: entry.target as HTMLDivElement,
         forceUpdate: true,
       }));
+
       updateNodeDimensions(updates);
     });
 

--- a/packages/core/src/contexts/NodeIdContext.ts
+++ b/packages/core/src/contexts/NodeIdContext.ts
@@ -1,7 +1,12 @@
-import { createContext } from 'react';
+import { createContext, useContext } from 'react';
 
 export const NodeIdContext = createContext<string | null>(null);
 export const Provider = NodeIdContext.Provider;
 export const Consumer = NodeIdContext.Consumer;
+
+export const useNodeId = (): string | null => {
+  const nodeId = useContext(NodeIdContext);
+  return nodeId;
+};
 
 export default NodeIdContext;

--- a/packages/core/src/hooks/useDrag/index.ts
+++ b/packages/core/src/hooks/useDrag/index.ts
@@ -1,15 +1,14 @@
-import { useEffect, useRef, useState, useCallback } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { RefObject, MouseEvent } from 'react';
 import { drag } from 'd3-drag';
 import { select } from 'd3-selection';
-import type { D3DragEvent, SubjectPosition } from 'd3';
 
 import { useStoreApi } from '../../hooks/useStore';
 import { getDragItems, getEventHandlerParams, hasSelector, calcNextPosition } from './utils';
 import { handleNodeClick } from '../../components/Nodes/utils';
-import type { NodeDragItem, Node, SelectionDragHandler } from '../../types';
+import useGetPointerPosition from '../useGetPointerPosition';
+import type { NodeDragItem, Node, SelectionDragHandler, UseDragEvent } from '../../types';
 
-export type UseDragEvent = D3DragEvent<HTMLDivElement, null, SubjectPosition>;
 export type UseDragData = { dx: number; dy: number };
 
 type UseDragParams = {
@@ -40,24 +39,7 @@ function useDrag({
   const dragItems = useRef<NodeDragItem[]>();
   const lastPos = useRef<{ x: number | null; y: number | null }>({ x: null, y: null });
 
-  // returns the pointer position projected to the RF coordinate system
-  const getPointerPosition = useCallback(({ sourceEvent }: UseDragEvent) => {
-    const { transform, snapGrid, snapToGrid } = store.getState();
-    const x = sourceEvent.touches ? sourceEvent.touches[0].clientX : sourceEvent.clientX;
-    const y = sourceEvent.touches ? sourceEvent.touches[0].clientY : sourceEvent.clientY;
-
-    const pointerPos = {
-      x: (x - transform[0]) / transform[2],
-      y: (y - transform[1]) / transform[2],
-    };
-
-    // we need the snapped position in order to be able to skip unnecessary drag events
-    return {
-      xSnapped: snapToGrid ? snapGrid[0] * Math.round(pointerPos.x / snapGrid[0]) : pointerPos.x,
-      ySnapped: snapToGrid ? snapGrid[1] * Math.round(pointerPos.y / snapGrid[1]) : pointerPos.y,
-      ...pointerPos,
-    };
-  }, []);
+  const getPointerPosition = useGetPointerPosition();
 
   useEffect(() => {
     if (nodeRef?.current) {

--- a/packages/core/src/hooks/useGetPointerPosition.ts
+++ b/packages/core/src/hooks/useGetPointerPosition.ts
@@ -1,0 +1,31 @@
+import { useCallback } from 'react';
+
+import { useStoreApi } from './useStore';
+import type { UseDragEvent } from '../types';
+
+function useGetPointerPosition() {
+  const store = useStoreApi();
+
+  // returns the pointer position projected to the RF coordinate system
+  const getPointerPosition = useCallback(({ sourceEvent }: UseDragEvent) => {
+    const { transform, snapGrid, snapToGrid } = store.getState();
+    const x = sourceEvent.touches ? sourceEvent.touches[0].clientX : sourceEvent.clientX;
+    const y = sourceEvent.touches ? sourceEvent.touches[0].clientY : sourceEvent.clientY;
+
+    const pointerPos = {
+      x: (x - transform[0]) / transform[2],
+      y: (y - transform[1]) / transform[2],
+    };
+
+    // we need the snapped position in order to be able to skip unnecessary drag events
+    return {
+      xSnapped: snapToGrid ? snapGrid[0] * Math.round(pointerPos.x / snapGrid[0]) : pointerPos.x,
+      ySnapped: snapToGrid ? snapGrid[1] * Math.round(pointerPos.y / snapGrid[1]) : pointerPos.y,
+      ...pointerPos,
+    };
+  }, []);
+
+  return getPointerPosition;
+}
+
+export default useGetPointerPosition;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,7 +22,6 @@ export {
   getNodePositionWithOrigin,
 } from './utils/graph';
 export { applyNodeChanges, applyEdgeChanges } from './utils/changes';
-export { createNodeInternals } from './store/utils';
 export { getMarkerEnd } from './components/Edges/utils';
 export { default as ReactFlowProvider } from './components/ReactFlowProvider';
 export { default as Panel } from './components/Panel';
@@ -40,5 +39,6 @@ export { default as useOnViewportChange } from './hooks/useOnViewportChange';
 export { default as useOnSelectionChange } from './hooks/useOnSelectionChange';
 export { default as useNodesInitialized } from './hooks/useNodesInitialized';
 export { default as useGetPointerPosition } from './hooks/useGetPointerPosition';
+export { useNodeId } from './contexts/NodeIdContext';
 
 export * from './types';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -37,5 +37,6 @@ export { useStore, useStoreApi } from './hooks/useStore';
 export { default as useOnViewportChange } from './hooks/useOnViewportChange';
 export { default as useOnSelectionChange } from './hooks/useOnSelectionChange';
 export { default as useNodesInitialized } from './hooks/useNodesInitialized';
+export { default as useGetPointerPosition } from './hooks/useGetPointerPosition';
 
 export * from './types';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,6 +22,7 @@ export {
   getNodePositionWithOrigin,
 } from './utils/graph';
 export { applyNodeChanges, applyEdgeChanges } from './utils/changes';
+export { createNodeInternals } from './store/utils';
 export { getMarkerEnd } from './components/Edges/utils';
 export { default as ReactFlowProvider } from './components/ReactFlowProvider';
 export { default as Panel } from './components/Panel';

--- a/packages/core/src/store/index.ts
+++ b/packages/core/src/store/index.ts
@@ -102,7 +102,12 @@ const createRFStore = () =>
         onNodesChange?.(changes);
       }
     },
-    updateNodePositions: (nodeDragItems: NodeDragItem[] | Node[], positionChanged = true, dragging = false) => {
+    updateNodePositions: (
+      nodeDragItems: NodeDragItem[] | Node[],
+      positionChanged = true,
+      dragging = false,
+      applyChanges = true
+    ) => {
       const { onNodesChange, nodeInternals, hasDefaultNodes, nodeOrigin } = get();
 
       if (hasDefaultNodes || onNodesChange) {
@@ -128,9 +133,15 @@ const createRFStore = () =>
             set({ nodeInternals: nextNodeInternals });
           }
 
-          onNodesChange?.(changes);
+          if (applyChanges) {
+            onNodesChange?.(changes);
+          }
         }
+
+        return changes;
       }
+
+      return null;
     },
     addSelectedNodes: (selectedNodeIds: string[]) => {
       const { multiSelectionActive, nodeInternals, edges } = get();

--- a/packages/core/src/types/changes.ts
+++ b/packages/core/src/types/changes.ts
@@ -7,8 +7,9 @@ import type { Edge } from './edges';
 export type NodeDimensionChange = {
   id: string;
   type: 'dimensions';
-  dimensions: Dimensions;
+  dimensions?: Dimensions;
   updateStyle?: boolean;
+  resizing?: boolean;
 };
 
 export type NodePositionChange = {

--- a/packages/core/src/types/changes.ts
+++ b/packages/core/src/types/changes.ts
@@ -8,6 +8,7 @@ export type NodeDimensionChange = {
   id: string;
   type: 'dimensions';
   dimensions: Dimensions;
+  updateStyle?: boolean;
 };
 
 export type NodePositionChange = {

--- a/packages/core/src/types/general.ts
+++ b/packages/core/src/types/general.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { MouseEvent as ReactMouseEvent, ComponentType, MemoExoticComponent } from 'react';
-import type { Selection as D3Selection, ZoomBehavior } from 'd3';
+import type { D3DragEvent, Selection as D3Selection, SubjectPosition, ZoomBehavior } from 'd3';
 
 import type { XYPosition, Rect, Transform, CoordinateExtent } from './utils';
 import type { NodeChange, EdgeChange } from './changes';
@@ -245,3 +245,5 @@ export type ProOptions = {
   account?: string;
   hideAttribution: boolean;
 };
+
+export type UseDragEvent = D3DragEvent<HTMLDivElement, null, SubjectPosition>;

--- a/packages/core/src/types/general.ts
+++ b/packages/core/src/types/general.ts
@@ -215,12 +215,7 @@ export type ReactFlowActions = {
   setEdges: (edges: Edge[]) => void;
   setDefaultNodesAndEdges: (nodes?: Node[], edges?: Edge[]) => void;
   updateNodeDimensions: (updates: NodeDimensionUpdate[]) => void;
-  updateNodePositions: (
-    nodeDragItems: NodeDragItem[] | Node[],
-    positionChanged: boolean,
-    dragging: boolean,
-    applyChanges?: boolean
-  ) => NodePositionChange[] | null;
+  updateNodePositions: (nodeDragItems: NodeDragItem[] | Node[], positionChanged: boolean, dragging: boolean) => void;
   resetSelectedElements: () => void;
   unselectNodesAndEdges: (params?: UnselectNodesAndEdgesParams) => void;
   addSelectedNodes: (nodeIds: string[]) => void;
@@ -231,6 +226,7 @@ export type ReactFlowActions = {
   setNodeExtent: (nodeExtent: CoordinateExtent) => void;
   cancelConnection: () => void;
   reset: () => void;
+  triggerNodeChanges: (changes: NodeChange[]) => void;
 };
 
 export type ReactFlowState = ReactFlowStore & ReactFlowActions;

--- a/packages/core/src/types/general.ts
+++ b/packages/core/src/types/general.ts
@@ -3,7 +3,7 @@ import type { MouseEvent as ReactMouseEvent, ComponentType, MemoExoticComponent 
 import type { D3DragEvent, Selection as D3Selection, SubjectPosition, ZoomBehavior } from 'd3';
 
 import type { XYPosition, Rect, Transform, CoordinateExtent } from './utils';
-import type { NodeChange, EdgeChange } from './changes';
+import type { NodeChange, EdgeChange, NodePositionChange } from './changes';
 import type {
   Node,
   NodeInternals,
@@ -215,7 +215,12 @@ export type ReactFlowActions = {
   setEdges: (edges: Edge[]) => void;
   setDefaultNodesAndEdges: (nodes?: Node[], edges?: Edge[]) => void;
   updateNodeDimensions: (updates: NodeDimensionUpdate[]) => void;
-  updateNodePositions: (nodeDragItems: NodeDragItem[] | Node[], positionChanged: boolean, dragging: boolean) => void;
+  updateNodePositions: (
+    nodeDragItems: NodeDragItem[] | Node[],
+    positionChanged: boolean,
+    dragging: boolean,
+    applyChanges?: boolean
+  ) => NodePositionChange[] | null;
   resetSelectedElements: () => void;
   unselectNodesAndEdges: (params?: UnselectNodesAndEdgesParams) => void;
   addSelectedNodes: (nodeIds: string[]) => void;

--- a/packages/core/src/types/nodes.ts
+++ b/packages/core/src/types/nodes.ts
@@ -31,6 +31,7 @@ export type Node<T = any> = {
   positionAbsolute?: XYPosition;
   ariaLabel?: string;
   focusable?: boolean;
+  resizing?: boolean;
 
   // only used internally
   [internalsSymbol]?: {

--- a/packages/core/src/utils/changes.ts
+++ b/packages/core/src/utils/changes.ts
@@ -94,6 +94,10 @@ function applyChanges(changes: any[], elements: any[]): any[] {
               updateItem.style = { ...(updateItem.style || {}), ...currentChange.dimensions };
             }
 
+            if (typeof currentChange.resizing === 'boolean') {
+              updateItem.resizing = currentChange.resizing;
+            }
+
             if (updateItem.expandParent) {
               handleParentExpand(res, updateItem);
             }

--- a/packages/core/src/utils/changes.ts
+++ b/packages/core/src/utils/changes.ts
@@ -50,58 +50,63 @@ function applyChanges(changes: any[], elements: any[]): any[] {
   const initElements: any[] = changes.filter((c) => c.type === 'add').map((c) => c.item);
 
   return elements.reduce((res: any[], item: any) => {
-    const currentChange = changes.find((c) => c.id === item.id);
+    const currentChanges = changes.filter((c) => c.id === item.id);
 
-    if (currentChange) {
-      switch (currentChange.type) {
-        case 'select': {
-          res.push({ ...item, selected: currentChange.selected });
-          return res;
-        }
-        case 'position': {
-          const updateItem = { ...item };
+    if (currentChanges.length === 0) {
+      res.push(item);
+      return res;
+    }
 
-          if (typeof currentChange.position !== 'undefined') {
-            updateItem.position = currentChange.position;
+    const updateItem = { ...item };
+
+    for (const currentChange of currentChanges) {
+      if (currentChange) {
+        switch (currentChange.type) {
+          case 'select': {
+            updateItem.selected = currentChange.selected;
+            break;
           }
+          case 'position': {
+            if (typeof currentChange.position !== 'undefined') {
+              updateItem.position = currentChange.position;
+            }
 
-          if (typeof currentChange.positionAbsolute !== 'undefined') {
-            updateItem.positionAbsolute = currentChange.positionAbsolute;
+            if (typeof currentChange.positionAbsolute !== 'undefined') {
+              updateItem.positionAbsolute = currentChange.positionAbsolute;
+            }
+
+            if (typeof currentChange.dragging !== 'undefined') {
+              updateItem.dragging = currentChange.dragging;
+            }
+
+            if (updateItem.expandParent) {
+              handleParentExpand(res, updateItem);
+            }
+            break;
           }
+          case 'dimensions': {
+            if (typeof currentChange.dimensions !== 'undefined') {
+              updateItem.width = currentChange.dimensions.width;
+              updateItem.height = currentChange.dimensions.height;
+            }
 
-          if (typeof currentChange.dragging !== 'undefined') {
-            updateItem.dragging = currentChange.dragging;
+            if (typeof currentChange.updateStyle !== 'undefined') {
+              updateItem.style = { ...(updateItem.style || {}), ...currentChange.dimensions };
+            }
+
+            if (updateItem.expandParent) {
+              handleParentExpand(res, updateItem);
+            }
+            break;
           }
-
-          if (updateItem.expandParent) {
-            handleParentExpand(res, updateItem);
+          case 'remove': {
+            return res;
           }
-
-          res.push(updateItem);
-          return res;
-        }
-        case 'dimensions': {
-          const updateItem = { ...item };
-
-          if (typeof currentChange.dimensions !== 'undefined') {
-            updateItem.width = currentChange.dimensions.width;
-            updateItem.height = currentChange.dimensions.height;
-          }
-
-          if (updateItem.expandParent) {
-            handleParentExpand(res, updateItem);
-          }
-
-          res.push(updateItem);
-          return res;
-        }
-        case 'remove': {
-          return res;
         }
       }
     }
 
-    res.push(item);
+    res.push(updateItem);
     return res;
   }, initElements);
 }

--- a/packages/node-resizer/.eslintrc.js
+++ b/packages/node-resizer/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  root: true,
+  extends: ['@reactflow/eslint-config'],
+};

--- a/packages/node-resizer/CHANGELOG.md
+++ b/packages/node-resizer/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @reactflow/node-resizer

--- a/packages/node-resizer/README.md
+++ b/packages/node-resizer/README.md
@@ -1,0 +1,10 @@
+# @reactflow/node-resizer
+
+A resizer component for React Flow that can be attached to a node.
+
+## Installation 
+
+```sh 
+npm install @reactflow/node-resizer
+```
+

--- a/packages/node-resizer/package.json
+++ b/packages/node-resizer/package.json
@@ -38,7 +38,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@babel/runtime": "^7.18.9",
     "@reactflow/core": "workspace:*",
     "classcat": "^5.0.4",
     "d3-drag": "^3.0.0",
@@ -53,7 +52,6 @@
     "@reactflow/eslint-config": "workspace:*",
     "@reactflow/rollup-config": "workspace:*",
     "@reactflow/tsconfig": "workspace:*",
-    "@types/d3": "^7.4.0",
     "@types/d3-drag": "^3.0.1",
     "@types/d3-selection": "^3.0.3",
     "@types/node": "^18.7.16",

--- a/packages/node-resizer/package.json
+++ b/packages/node-resizer/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@babel/runtime": "^7.18.9",
     "@reactflow/core": "workspace:*",
-    "classcat": "^5.0.3",
+    "classcat": "^5.0.4",
     "d3-drag": "^3.0.0",
     "d3-selection": "^3.0.0",
     "zustand": "^4.1.1"

--- a/packages/node-resizer/package.json
+++ b/packages/node-resizer/package.json
@@ -31,7 +31,9 @@
   },
   "scripts": {
     "dev": "concurrently \"rollup --config node:@reactflow/rollup-config --watch\" pnpm:css-watch",
-    "build": "rollup --config node:@reactflow/rollup-config --environment NODE_ENV:production",
+    "build": "rollup --config node:@reactflow/rollup-config --environment NODE_ENV:production && npm run css",
+    "css": "postcss src/*.css --config ../../tooling/postcss-config/postcss.config.js --dir dist",
+    "css-watch": "pnpm css --watch",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx src",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/node-resizer/package.json
+++ b/packages/node-resizer/package.json
@@ -1,0 +1,71 @@
+{
+  "name": "@reactflow/node-resizer",
+  "version": "0.0.0",
+  "description": "A helper component for resizing nodes.",
+  "keywords": [
+    "react",
+    "node-based UI",
+    "graph",
+    "diagram",
+    "workflow",
+    "react-flow"
+  ],
+  "files": [
+    "dist"
+  ],
+  "source": "src/index.tsx",
+  "main": "dist/umd/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/esm/index.d.ts",
+  "sideEffects": [
+    "*.css"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/wbkd/react-flow.git",
+    "directory": "packages/node-resizer"
+  },
+  "scripts": {
+    "dev": "concurrently \"rollup --config node:@reactflow/rollup-config --watch\" pnpm:css-watch",
+    "build": "rollup --config node:@reactflow/rollup-config --environment NODE_ENV:production",
+    "lint": "eslint --ext .js,.jsx,.ts,.tsx src",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@babel/runtime": "^7.18.9",
+    "@reactflow/core": "workspace:*",
+    "classcat": "^5.0.3",
+    "d3-drag": "^3.0.0",
+    "d3-selection": "^3.0.0",
+    "zustand": "^4.1.1"
+  },
+  "peerDependencies": {
+    "react": ">=17",
+    "react-dom": ">=17"
+  },
+  "devDependencies": {
+    "@reactflow/eslint-config": "workspace:*",
+    "@reactflow/rollup-config": "workspace:*",
+    "@reactflow/tsconfig": "workspace:*",
+    "@types/d3": "^7.4.0",
+    "@types/d3-drag": "^3.0.1",
+    "@types/d3-selection": "^3.0.3",
+    "@types/node": "^18.7.16",
+    "@types/react": "^18.0.19",
+    "@types/react-dom": "^18.0.6",
+    "react": "^18.2.0",
+    "typescript": "^4.8.3"
+  },
+  "rollup": {
+    "globals": {
+      "zustand": "Zustand",
+      "zustand/shallow": "zustandShallow",
+      "classcat": "cc"
+    },
+    "name": "ReactFlowNodeResizer"
+  }
+}

--- a/packages/node-resizer/src/NodeResizer.tsx
+++ b/packages/node-resizer/src/NodeResizer.tsx
@@ -1,179 +1,25 @@
-import { useRef, useEffect } from 'react';
-import cc from 'classcat';
-import { drag } from 'd3-drag';
-import { select } from 'd3-selection';
-import {
-  useStoreApi,
-  useGetPointerPosition,
-  NodeChange,
-  NodePositionChange,
-  NodeDimensionChange,
-} from '@reactflow/core';
-import type { Dimensions, Node, XYPosition } from '@reactflow/core';
-import type { D3DragEvent, SubjectPosition } from 'd3';
+import ResizeControl from './ResizeControl';
+import type { NodeResizerProps } from './types';
 
-type NodeResizerProps = {
-  nodeId: string;
-};
-
-type ResizeHandleProps = {
-  nodeId: string;
-  invertX?: boolean;
-  invertY?: boolean;
-  enableX?: boolean;
-  enableY?: boolean;
-  top?: number | string;
-  left?: number | string;
-  className?: string;
-};
-
-type ResizeDragEvent = D3DragEvent<HTMLDivElement, null, SubjectPosition>;
-
-function ResizeHandle({
-  top = 0,
-  left = 0,
-  invertX = false,
-  invertY = false,
-  enableX = false,
-  enableY = false,
+export default function NodeResizer({
   nodeId,
-  className,
-}: ResizeHandleProps) {
-  const store = useStoreApi();
-  const resizeHandleRef = useRef<HTMLDivElement>(null);
-  const initialDimensionsRef = useRef<Dimensions & XYPosition & { nodeX: number; nodeY: number }>({
-    width: 0,
-    height: 0,
-    x: 0,
-    y: 0,
-    nodeX: 0,
-    nodeY: 0,
-  });
-  const nodeElementRef = useRef<HTMLDivElement | null>(null);
-  const getPointerPosition = useGetPointerPosition();
-
-  useEffect(() => {
-    if (!resizeHandleRef.current) {
-      return;
-    }
-
-    const selection = select(resizeHandleRef.current);
-    const dragHandler = drag<HTMLDivElement, unknown>()
-      .on('start', (event: ResizeDragEvent) => {
-        const node = store.getState().nodeInternals.get(nodeId);
-        const pointerPos = getPointerPosition(event);
-
-        initialDimensionsRef.current = {
-          width: node?.width ?? 0,
-          height: node?.height ?? 0,
-          nodeX: node?.position.x ?? 0,
-          nodeY: node?.position.y ?? 0,
-          x: pointerPos.xSnapped,
-          y: pointerPos.ySnapped,
-        };
-        nodeElementRef.current = document.querySelector(`.react-flow__node[data-id="${nodeId}"]`) as HTMLDivElement;
-      })
-      .on('drag', (event: ResizeDragEvent) => {
-        const { updateNodePositions, nodeInternals, onNodesChange } = store.getState();
-        const pointerPos = getPointerPosition(event);
-        const nodeEl = nodeElementRef.current;
-        const node = nodeInternals.get(nodeId);
-
-        if (nodeEl && node) {
-          const changes: NodeChange[] = [];
-          const distX = enableX ? pointerPos.xSnapped - initialDimensionsRef.current.x : 0;
-          const distY = enableY ? pointerPos.ySnapped - initialDimensionsRef.current.y : 0;
-          const width = initialDimensionsRef.current.width + (invertX ? -distX : distX);
-          const height = initialDimensionsRef.current.height + (invertY ? -distY : distY);
-
-          if (invertX || invertY) {
-            const x = invertX ? initialDimensionsRef.current.nodeX + distX : initialDimensionsRef.current.nodeX;
-            const y = invertY ? initialDimensionsRef.current.nodeY + distY : initialDimensionsRef.current.nodeY;
-
-            if (x !== node.position.x || y !== node.position.y) {
-              const positionChanges: NodePositionChange[] | null = updateNodePositions(
-                [
-                  {
-                    id: nodeId,
-                    position: { x, y },
-                  } as Node,
-                ],
-                true,
-                false,
-                false
-              );
-
-              if (positionChanges?.length) {
-                changes.push(positionChanges[0]);
-              }
-            }
-          }
-
-          if (width !== node.width || height !== node.height) {
-            const dimensionChange: NodeDimensionChange = {
-              id: nodeId,
-              type: 'dimensions',
-              updateStyle: true,
-              dimensions: {
-                width: width !== node.width ? width : node.width,
-                height: height !== node.height ? height : node.height,
-              },
-            };
-            changes.push(dimensionChange);
-          }
-
-          if (changes.length) {
-            onNodesChange?.(changes);
-          }
-        }
-      });
-
-    selection.call(dragHandler);
-
-    return () => {
-      selection.on('.drag', null);
-    };
-  }, [nodeId]);
-
-  return (
-    <div
-      className={cc([className, 'nodrag'])}
-      ref={resizeHandleRef}
-      style={{
-        position: 'absolute',
-        left,
-        top,
-        width: 10,
-        height: 10,
-        background: 'red',
-        opacity: 0.7,
-        borderRadius: '50%',
-        transform: 'translate(-50%, -50%)',
-      }}
-    />
-  );
-}
-
-export default function NodeResizer({ nodeId }: NodeResizerProps) {
+  handleClassName,
+  handleStyle,
+  lineClassName,
+  lineStyle,
+}: NodeResizerProps) {
   return (
     <>
-      <ResizeHandle
-        className="react-flow__node-resizer"
-        nodeId={nodeId}
-        top={0}
-        left={0}
-        enableX
-        enableY
-        invertX
-        invertY
-      />
-      <ResizeHandle className="react-flow__node-resizer" nodeId={nodeId} top="50%" left={0} enableX invertX />
-      <ResizeHandle className="react-flow__node-resizer" nodeId={nodeId} top="100%" left={0} enableX enableY />
-      <ResizeHandle className="react-flow__node-resizer" nodeId={nodeId} top={0} left="50%" enableY invertY />
-      <ResizeHandle className="react-flow__node-resizer" nodeId={nodeId} top={0} left="100%" enableX enableY invertY />
-      <ResizeHandle className="react-flow__node-resizer" nodeId={nodeId} top="50%" left="100%" enableX />
-      <ResizeHandle className="react-flow__node-resizer" nodeId={nodeId} top="100%" left="100%" enableX enableY />
-      <ResizeHandle className="react-flow__node-resizer" nodeId={nodeId} top="100%" left="50%" enableY />
+      <ResizeControl className={handleClassName} style={handleStyle} nodeId={nodeId} position="top-left" />
+      <ResizeControl className={lineClassName} variant="line" style={lineStyle} nodeId={nodeId} position="top" />
+      <ResizeControl className={handleClassName} style={handleStyle} nodeId={nodeId} position="top-right" />
+
+      <ResizeControl className={lineClassName} variant="line" style={lineStyle} nodeId={nodeId} position="left" />
+
+      <ResizeControl className={handleClassName} style={handleStyle} nodeId={nodeId} position="bottom-left" />
+      <ResizeControl className={lineClassName} variant="line" style={lineStyle} nodeId={nodeId} position="right" />
+      <ResizeControl className={handleClassName} style={handleStyle} nodeId={nodeId} position="bottom-right" />
+      <ResizeControl className={lineClassName} variant="line" position="bottom" style={lineStyle} nodeId={nodeId} />
     </>
   );
 }

--- a/packages/node-resizer/src/NodeResizer.tsx
+++ b/packages/node-resizer/src/NodeResizer.tsx
@@ -1,9 +1,9 @@
 import { useRef, useEffect } from 'react';
 import { drag } from 'd3-drag';
 import { select } from 'd3-selection';
-import type { D3DragEvent, SubjectPosition } from 'd3';
 import { useStoreApi, useGetPointerPosition } from '@reactflow/core';
 import type { Dimensions, Node, XYPosition } from '@reactflow/core';
+import type { D3DragEvent, SubjectPosition } from 'd3';
 
 type NodeResizerProps = {
   nodeId: string;
@@ -77,8 +77,8 @@ function ResizeHandle({
           const height = initialDimensionsRef.current.height + (invertY ? -distY : distY);
 
           if (invertX || invertY) {
-            const x = invertX ? initialDimensionsRef.current.nodeX + distX : node.position.x;
-            const y = invertY ? initialDimensionsRef.current.nodeY + distY : node.position.y;
+            const x = invertX ? initialDimensionsRef.current.nodeX + distX : initialDimensionsRef.current.nodeX;
+            const y = invertY ? initialDimensionsRef.current.nodeY + distY : initialDimensionsRef.current.nodeY;
 
             if (x !== node.position.x || y !== node.position.y) {
               updateNodePositions(

--- a/packages/node-resizer/src/NodeResizer.tsx
+++ b/packages/node-resizer/src/NodeResizer.tsx
@@ -1,5 +1,8 @@
 import ResizeControl from './ResizeControl';
-import type { NodeResizerProps } from './types';
+import { ControlPosition, NodeResizerProps, ResizeControlVariant, ControlLinePosition } from './types';
+
+const handleControls: ControlPosition[] = ['top-left', 'top-right', 'bottom-left', 'bottom-right'];
+const lineControls: ControlLinePosition[] = ['top', 'right', 'bottom', 'left'];
 
 export default function NodeResizer({
   nodeId,
@@ -10,16 +13,19 @@ export default function NodeResizer({
 }: NodeResizerProps) {
   return (
     <>
-      <ResizeControl className={handleClassName} style={handleStyle} nodeId={nodeId} position="top-left" />
-      <ResizeControl className={lineClassName} variant="line" style={lineStyle} nodeId={nodeId} position="top" />
-      <ResizeControl className={handleClassName} style={handleStyle} nodeId={nodeId} position="top-right" />
-
-      <ResizeControl className={lineClassName} variant="line" style={lineStyle} nodeId={nodeId} position="left" />
-
-      <ResizeControl className={handleClassName} style={handleStyle} nodeId={nodeId} position="bottom-left" />
-      <ResizeControl className={lineClassName} variant="line" style={lineStyle} nodeId={nodeId} position="right" />
-      <ResizeControl className={handleClassName} style={handleStyle} nodeId={nodeId} position="bottom-right" />
-      <ResizeControl className={lineClassName} variant="line" position="bottom" style={lineStyle} nodeId={nodeId} />
+      {lineControls.map((c) => (
+        <ResizeControl
+          key={c}
+          className={lineClassName}
+          style={lineStyle}
+          nodeId={nodeId}
+          position={c}
+          variant={ResizeControlVariant.Line}
+        />
+      ))}
+      {handleControls.map((c) => (
+        <ResizeControl key={c} className={handleClassName} style={handleStyle} nodeId={nodeId} position={c} />
+      ))}
     </>
   );
 }

--- a/packages/node-resizer/src/NodeResizer.tsx
+++ b/packages/node-resizer/src/NodeResizer.tsx
@@ -6,11 +6,17 @@ const lineControls: ControlLinePosition[] = ['top', 'right', 'bottom', 'left'];
 
 export default function NodeResizer({
   nodeId,
+  isVisible = true,
   handleClassName,
   handleStyle,
   lineClassName,
   lineStyle,
+  color,
 }: NodeResizerProps) {
+  if (!isVisible) {
+    return null;
+  }
+
   return (
     <>
       {lineControls.map((c) => (
@@ -21,10 +27,18 @@ export default function NodeResizer({
           nodeId={nodeId}
           position={c}
           variant={ResizeControlVariant.Line}
+          color={color}
         />
       ))}
       {handleControls.map((c) => (
-        <ResizeControl key={c} className={handleClassName} style={handleStyle} nodeId={nodeId} position={c} />
+        <ResizeControl
+          key={c}
+          className={handleClassName}
+          style={handleStyle}
+          nodeId={nodeId}
+          position={c}
+          color={color}
+        />
       ))}
     </>
   );

--- a/packages/node-resizer/src/ResizeControl.tsx
+++ b/packages/node-resizer/src/ResizeControl.tsx
@@ -8,6 +8,8 @@ import {
   NodeChange,
   NodePositionChange,
   NodeDimensionChange,
+  applyNodeChanges,
+  createNodeInternals,
 } from '@reactflow/core';
 import type { Dimensions, Node, XYPosition } from '@reactflow/core';
 
@@ -56,7 +58,7 @@ function ResizeControl({
         nodeElementRef.current = document.querySelector(`.react-flow__node[data-id="${nodeId}"]`) as HTMLDivElement;
       })
       .on('drag', (event: ResizeDragEvent) => {
-        const { updateNodePositions, nodeInternals, onNodesChange } = store.getState();
+        const { updateNodePositions, nodeInternals, onNodesChange, hasDefaultNodes, nodeOrigin } = store.getState();
         const pointerPos = getPointerPosition(event);
         const nodeEl = nodeElementRef.current;
         const node = nodeInternals.get(nodeId);
@@ -109,6 +111,12 @@ function ResizeControl({
           }
 
           if (changes.length) {
+            if (hasDefaultNodes) {
+              const nodes = applyNodeChanges(changes, Array.from(nodeInternals.values()));
+              const nextNodeInternals = createNodeInternals(nodes, nodeInternals, nodeOrigin);
+              store.setState({ nodeInternals: nextNodeInternals });
+            }
+
             onNodesChange?.(changes);
           }
         }

--- a/packages/node-resizer/src/ResizeControl.tsx
+++ b/packages/node-resizer/src/ResizeControl.tsx
@@ -1,0 +1,141 @@
+import { useRef, useEffect } from 'react';
+import cc from 'classcat';
+import { drag } from 'd3-drag';
+import { select } from 'd3-selection';
+import {
+  useStoreApi,
+  useGetPointerPosition,
+  NodeChange,
+  NodePositionChange,
+  NodeDimensionChange,
+} from '@reactflow/core';
+import type { Dimensions, Node, XYPosition } from '@reactflow/core';
+
+import type { ResizeDragEvent, ResizeControlProps, ResizeControlLineProps } from './types';
+
+function ResizeControl({
+  nodeId,
+  position = 'bottom-right',
+  variant = 'handle',
+  className,
+  style = {},
+  children,
+}: ResizeControlProps) {
+  const store = useStoreApi();
+  const resizeHandleRef = useRef<HTMLDivElement>(null);
+  const initialDimensionsRef = useRef<Dimensions & XYPosition & { nodeX: number; nodeY: number }>({
+    width: 0,
+    height: 0,
+    x: 0,
+    y: 0,
+    nodeX: 0,
+    nodeY: 0,
+  });
+  const nodeElementRef = useRef<HTMLDivElement | null>(null);
+  const getPointerPosition = useGetPointerPosition();
+
+  useEffect(() => {
+    if (!resizeHandleRef.current) {
+      return;
+    }
+
+    const selection = select(resizeHandleRef.current);
+    const dragHandler = drag<HTMLDivElement, unknown>()
+      .on('start', (event: ResizeDragEvent) => {
+        const node = store.getState().nodeInternals.get(nodeId);
+        const pointerPos = getPointerPosition(event);
+
+        initialDimensionsRef.current = {
+          width: node?.width ?? 0,
+          height: node?.height ?? 0,
+          nodeX: node?.position.x ?? 0,
+          nodeY: node?.position.y ?? 0,
+          x: pointerPos.xSnapped,
+          y: pointerPos.ySnapped,
+        };
+        nodeElementRef.current = document.querySelector(`.react-flow__node[data-id="${nodeId}"]`) as HTMLDivElement;
+      })
+      .on('drag', (event: ResizeDragEvent) => {
+        const { updateNodePositions, nodeInternals, onNodesChange } = store.getState();
+        const pointerPos = getPointerPosition(event);
+        const nodeEl = nodeElementRef.current;
+        const node = nodeInternals.get(nodeId);
+        const enableX = position.includes('right') || position.includes('left');
+        const enableY = position.includes('bottom') || position.includes('top');
+        const invertX = position.includes('left');
+        const invertY = position.includes('top');
+
+        if (nodeEl && node) {
+          const changes: NodeChange[] = [];
+          const distX = enableX ? pointerPos.xSnapped - initialDimensionsRef.current.x : 0;
+          const distY = enableY ? pointerPos.ySnapped - initialDimensionsRef.current.y : 0;
+          const width = initialDimensionsRef.current.width + (invertX ? -distX : distX);
+          const height = initialDimensionsRef.current.height + (invertY ? -distY : distY);
+
+          if (invertX || invertY) {
+            const x = invertX ? initialDimensionsRef.current.nodeX + distX : initialDimensionsRef.current.nodeX;
+            const y = invertY ? initialDimensionsRef.current.nodeY + distY : initialDimensionsRef.current.nodeY;
+
+            if (x !== node.position.x || y !== node.position.y) {
+              const positionChanges: NodePositionChange[] | null = updateNodePositions(
+                [
+                  {
+                    id: nodeId,
+                    position: { x, y },
+                  } as Node,
+                ],
+                true,
+                false,
+                false
+              );
+
+              if (positionChanges?.length) {
+                changes.push(positionChanges[0]);
+              }
+            }
+          }
+
+          if (width !== node.width || height !== node.height) {
+            const dimensionChange: NodeDimensionChange = {
+              id: nodeId,
+              type: 'dimensions',
+              updateStyle: true,
+              dimensions: {
+                width: width !== node.width ? width : node.width,
+                height: height !== node.height ? height : node.height,
+              },
+            };
+            changes.push(dimensionChange);
+          }
+
+          if (changes.length) {
+            onNodesChange?.(changes);
+          }
+        }
+      });
+
+    selection.call(dragHandler);
+
+    return () => {
+      selection.on('.drag', null);
+    };
+  }, [nodeId, position, getPointerPosition]);
+
+  const positionClassNames = position.split('-');
+
+  return (
+    <div
+      className={cc([className, ...positionClassNames, variant, 'react-flow__resize-control', 'nodrag'])}
+      ref={resizeHandleRef}
+      style={style}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function ResizeControlLine(props: ResizeControlLineProps) {
+  return <ResizeControl {...props} variant="line" />;
+}
+
+export default ResizeControl;

--- a/packages/node-resizer/src/index.tsx
+++ b/packages/node-resizer/src/index.tsx
@@ -1,2 +1,4 @@
 export { default as NodeResizer } from './NodeResizer';
+export { default as NodeResizeControl } from './ResizeControl';
+
 export * from './types';

--- a/packages/node-resizer/src/index.tsx
+++ b/packages/node-resizer/src/index.tsx
@@ -1,0 +1,2 @@
+export { default as NodeResizer } from './NodeResizer';
+export * from './types';

--- a/packages/node-resizer/src/style.css
+++ b/packages/node-resizer/src/style.css
@@ -1,9 +1,5 @@
 .react-flow__resize-control {
   position: absolute;
-  background-color: rgba(195, 195, 195, 1);
-  border: 1px solid white;
-  width: 4px;
-  height: 4px;
 }
 
 .react-flow__resize-control.left,
@@ -28,6 +24,11 @@
 
 /* handle styles */
 .react-flow__resize-control.handle {
+  width: 4px;
+  height: 4px;
+  border: 1px solid #fff;
+  border-radius: 1px;
+  background-color: #3367d9;
   transform: translate(-50%, -50%);
 }
 
@@ -62,9 +63,11 @@
 
 /* line styles */
 .react-flow__resize-control.line {
-  border: none;
-  background: none;
+  border-color: #3367d9;
+  border-width: 0;
+  border-style: solid;
 }
+
 .react-flow__resize-control.line.left,
 .react-flow__resize-control.line.right {
   width: 1px;
@@ -75,11 +78,11 @@
 
 .react-flow__resize-control.line.left {
   left: 0;
-  border-left: 1px solid rgba(195, 195, 195, 1);
+  border-left-width: 1px;
 }
 .react-flow__resize-control.line.right {
   left: 100%;
-  border-right: 1px solid rgba(195, 195, 195, 1);
+  border-right-width: 1px;
 }
 
 .react-flow__resize-control.line.top,
@@ -92,9 +95,9 @@
 
 .react-flow__resize-control.line.top {
   top: 0;
-  border-top: 1px solid rgba(195, 195, 195, 1);
+  border-top-width: 1px;
 }
 .react-flow__resize-control.line.bottom {
-  border-bottom: 1px solid rgba(195, 195, 195, 1);
+  border-bottom-width: 1px;
   top: 100%;
 }

--- a/packages/node-resizer/src/style.css
+++ b/packages/node-resizer/src/style.css
@@ -1,0 +1,100 @@
+.react-flow__resize-control {
+  position: absolute;
+  background-color: rgba(195, 195, 195, 1);
+  border: 1px solid white;
+  width: 4px;
+  height: 4px;
+}
+
+.react-flow__resize-control.left,
+.react-flow__resize-control.right {
+  cursor: ew-resize;
+}
+
+.react-flow__resize-control.top,
+.react-flow__resize-control.bottom {
+  cursor: ns-resize;
+}
+
+.react-flow__resize-control.top.left,
+.react-flow__resize-control.bottom.right {
+  cursor: nwse-resize;
+}
+
+.react-flow__resize-control.bottom.left,
+.react-flow__resize-control.top.right {
+  cursor: nesw-resize;
+}
+
+/* handle styles */
+.react-flow__resize-control.handle {
+  transform: translate(-50%, -50%);
+}
+
+.react-flow__resize-control.handle.left {
+  left: 0;
+  top: 50%;
+}
+.react-flow__resize-control.handle.right {
+  left: 100%;
+  top: 50%;
+}
+.react-flow__resize-control.handle.top {
+  left: 50%;
+  top: 0;
+}
+.react-flow__resize-control.handle.bottom {
+  left: 50%;
+  top: 100%;
+}
+.react-flow__resize-control.handle.top.left {
+  left: 0;
+}
+.react-flow__resize-control.handle.bottom.left {
+  left: 0;
+}
+.react-flow__resize-control.handle.top.right {
+  left: 100%;
+}
+.react-flow__resize-control.handle.bottom.right {
+  left: 100%;
+}
+
+/* line styles */
+.react-flow__resize-control.line {
+  border: none;
+  background: none;
+}
+.react-flow__resize-control.line.left,
+.react-flow__resize-control.line.right {
+  width: 1px;
+  transform: translate(-50%, 0);
+  top: 0;
+  height: 100%;
+}
+
+.react-flow__resize-control.line.left {
+  left: 0;
+  border-left: 1px solid rgba(195, 195, 195, 1);
+}
+.react-flow__resize-control.line.right {
+  left: 100%;
+  border-right: 1px solid rgba(195, 195, 195, 1);
+}
+
+.react-flow__resize-control.line.top,
+.react-flow__resize-control.line.bottom {
+  height: 1px;
+  transform: translate(0, -50%);
+  left: 0;
+  width: 100%;
+}
+
+.react-flow__resize-control.line.top {
+  top: 0;
+  border-top: 1px solid rgba(195, 195, 195, 1);
+}
+.react-flow__resize-control.line.bottom {
+  border-bottom: 1px solid rgba(195, 195, 195, 1);
+  top: 100%;
+}

--- a/packages/node-resizer/src/types.ts
+++ b/packages/node-resizer/src/types.ts
@@ -1,0 +1,9 @@
+import { Position } from '@reactflow/core';
+import type { HTMLAttributes } from 'react';
+
+export type NodeToolbarProps = HTMLAttributes<HTMLDivElement> & {
+  nodeId: string;
+  isVisible?: boolean;
+  position?: Position;
+  offset?: number;
+};

--- a/packages/node-resizer/src/types.ts
+++ b/packages/node-resizer/src/types.ts
@@ -1,9 +1,29 @@
-import { Position } from '@reactflow/core';
-import type { HTMLAttributes } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
+import type { D3DragEvent, SubjectPosition } from 'd3-drag';
 
-export type NodeToolbarProps = HTMLAttributes<HTMLDivElement> & {
+export type NodeResizerProps = {
   nodeId: string;
-  isVisible?: boolean;
-  position?: Position;
-  offset?: number;
+  handleClassName?: string;
+  handleStyle?: CSSProperties;
+  lineClassName?: string;
+  lineStyle?: CSSProperties;
 };
+
+export type ControlLinePosition = 'top' | 'bottom' | 'left' | 'right';
+
+export type ControlPosition = ControlLinePosition | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+
+export type ResizeControlProps = {
+  nodeId: string;
+  position: ControlPosition;
+  variant?: 'line' | 'handle';
+  className?: string;
+  style?: CSSProperties;
+  children?: ReactNode;
+};
+
+export type ResizeControlLineProps = ResizeControlProps & {
+  position: ControlLinePosition;
+};
+
+export type ResizeDragEvent = D3DragEvent<HTMLDivElement, null, SubjectPosition>;

--- a/packages/node-resizer/src/types.ts
+++ b/packages/node-resizer/src/types.ts
@@ -13,10 +13,15 @@ export type ControlLinePosition = 'top' | 'bottom' | 'left' | 'right';
 
 export type ControlPosition = ControlLinePosition | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
 
+export enum ResizeControlVariant {
+  Line = 'line',
+  Handle = 'handle',
+}
+
 export type ResizeControlProps = {
   nodeId: string;
   position: ControlPosition;
-  variant?: 'line' | 'handle';
+  variant?: ResizeControlVariant;
   className?: string;
   style?: CSSProperties;
   children?: ReactNode;

--- a/packages/node-resizer/src/types.ts
+++ b/packages/node-resizer/src/types.ts
@@ -2,11 +2,13 @@ import type { CSSProperties, ReactNode } from 'react';
 import type { D3DragEvent, SubjectPosition } from 'd3-drag';
 
 export type NodeResizerProps = {
-  nodeId: string;
+  nodeId?: string;
+  color?: string;
   handleClassName?: string;
   handleStyle?: CSSProperties;
   lineClassName?: string;
   lineStyle?: CSSProperties;
+  isVisible?: boolean;
 };
 
 export type ControlLinePosition = 'top' | 'bottom' | 'left' | 'right';
@@ -19,12 +21,15 @@ export enum ResizeControlVariant {
 }
 
 export type ResizeControlProps = {
-  nodeId: string;
-  position: ControlPosition;
+  nodeId?: string;
+  position?: ControlPosition;
   variant?: ResizeControlVariant;
+  color?: string;
   className?: string;
   style?: CSSProperties;
   children?: ReactNode;
+  minWidth?: number;
+  minHeight?: number;
 };
 
 export type ResizeControlLineProps = ResizeControlProps & {

--- a/packages/node-resizer/tsconfig.json
+++ b/packages/node-resizer/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "@reactflow/tsconfig/react.json",
+  "display": "@reactflow/node-resizer",
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/node-toolbar/src/NodeToolbar.tsx
+++ b/packages/node-toolbar/src/NodeToolbar.tsx
@@ -8,6 +8,7 @@ import {
   Rect,
   Position,
   internalsSymbol,
+  useNodeId,
 } from '@reactflow/core';
 import cc from 'classcat';
 import shallow from 'zustand/shallow';
@@ -72,9 +73,11 @@ function NodeToolbar({
   offset = 10,
   ...rest
 }: NodeToolbarProps) {
+  const contextNodeId = useNodeId();
+
   const nodesSelector = useCallback(
     (state: ReactFlowState): Node[] => {
-      const nodeIds: string[] = typeof nodeId === 'string' ? [nodeId] : nodeId;
+      const nodeIds = Array.isArray(nodeId) ? nodeId : [nodeId || contextNodeId || ''];
 
       return nodeIds.reduce<Node[]>((acc, id) => {
         const node = state.nodeInternals.get(id);
@@ -84,7 +87,7 @@ function NodeToolbar({
         return acc;
       }, [] as Node[]);
     },
-    [nodeId]
+    [nodeId, contextNodeId]
   );
   const nodes = useStore(nodesSelector, nodesEqualityFn);
   const { transform, nodeOrigin, selectedNodesCount } = useStore(storeSelector, shallow);

--- a/packages/node-toolbar/src/types.ts
+++ b/packages/node-toolbar/src/types.ts
@@ -2,7 +2,7 @@ import { Position } from '@reactflow/core';
 import type { HTMLAttributes } from 'react';
 
 export type NodeToolbarProps = HTMLAttributes<HTMLDivElement> & {
-  nodeId: string | string[];
+  nodeId?: string | string[];
   isVisible?: boolean;
   position?: Position;
   offset?: number;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,7 @@ importers:
   examples/vite-app:
     specifiers:
       '@cypress/skip-test': ^2.6.1
+      '@reactflow/node-resizer': workspace:^0.0.0
       '@types/react': ^18.0.17
       '@types/react-dom': ^18.0.6
       '@vitejs/plugin-react': ^2.1.0
@@ -73,6 +74,7 @@ importers:
       typescript: ^4.8.3
       vite: ^3.1.0
     dependencies:
+      '@reactflow/node-resizer': link:../../packages/node-resizer
       classcat: registry.npmjs.org/classcat/5.0.4
       dagre: registry.npmjs.org/dagre/0.8.5
       localforage: registry.npmjs.org/localforage/1.10.0
@@ -212,6 +214,45 @@ importers:
       '@reactflow/tsconfig': link:../../tooling/tsconfig
       '@types/node': registry.npmjs.org/@types/node/18.7.16
       '@types/react': registry.npmjs.org/@types/react/18.0.19
+      react: registry.npmjs.org/react/18.2.0
+      typescript: registry.npmjs.org/typescript/4.8.3
+
+  packages/node-resizer:
+    specifiers:
+      '@babel/runtime': ^7.18.9
+      '@reactflow/core': workspace:*
+      '@reactflow/eslint-config': workspace:*
+      '@reactflow/rollup-config': workspace:*
+      '@reactflow/tsconfig': workspace:*
+      '@types/d3': ^7.4.0
+      '@types/d3-drag': ^3.0.1
+      '@types/d3-selection': ^3.0.3
+      '@types/node': ^18.7.16
+      '@types/react': ^18.0.19
+      '@types/react-dom': ^18.0.6
+      classcat: ^5.0.3
+      d3-drag: ^3.0.0
+      d3-selection: ^3.0.0
+      react: ^18.2.0
+      typescript: ^4.8.3
+      zustand: ^4.1.1
+    dependencies:
+      '@babel/runtime': registry.npmjs.org/@babel/runtime/7.19.0
+      '@reactflow/core': link:../core
+      classcat: registry.npmjs.org/classcat/5.0.4
+      d3-drag: registry.npmjs.org/d3-drag/3.0.0
+      d3-selection: registry.npmjs.org/d3-selection/3.0.0
+      zustand: registry.npmjs.org/zustand/4.1.1_react@18.2.0
+    devDependencies:
+      '@reactflow/eslint-config': link:../../tooling/eslint-config
+      '@reactflow/rollup-config': link:../../tooling/rollup-config
+      '@reactflow/tsconfig': link:../../tooling/tsconfig
+      '@types/d3': registry.npmjs.org/@types/d3/7.4.0
+      '@types/d3-drag': registry.npmjs.org/@types/d3-drag/3.0.1
+      '@types/d3-selection': registry.npmjs.org/@types/d3-selection/3.0.3
+      '@types/node': registry.npmjs.org/@types/node/18.7.16
+      '@types/react': registry.npmjs.org/@types/react/18.0.19
+      '@types/react-dom': registry.npmjs.org/@types/react-dom/18.0.6
       react: registry.npmjs.org/react/18.2.0
       typescript: registry.npmjs.org/typescript/4.8.3
 
@@ -1380,7 +1421,6 @@ packages:
     resolution: {integrity: sha512-Reoy+pKnvsksN0lQUlcH6dOGjRZ/3WRwXR//m+/8lt1BXeI4xyaUZoqULNjyXXRuh0Mj4LNpkCvhUpQlY3X5xQ==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/d3-array/-/d3-array-3.0.3.tgz}
     name: '@types/d3-array'
     version: 3.0.3
-    dev: false
 
   registry.npmjs.org/@types/d3-axis/3.0.1:
     resolution: {integrity: sha512-zji/iIbdd49g9WN0aIsGcwcTBUkgLsCSwB+uH+LPVDAiKWENMtI3cJEWt+7/YYwelMoZmbBfzA3qCdrZ2XFNnw==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.1.tgz}
@@ -1388,7 +1428,6 @@ packages:
     version: 3.0.1
     dependencies:
       '@types/d3-selection': registry.npmjs.org/@types/d3-selection/3.0.3
-    dev: false
 
   registry.npmjs.org/@types/d3-brush/3.0.1:
     resolution: {integrity: sha512-B532DozsiTuQMHu2YChdZU0qsFJSio3Q6jmBYGYNp3gMDzBmuFFgPt9qKA4VYuLZMp4qc6eX7IUFUEsvHiXZAw==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.1.tgz}
@@ -1396,19 +1435,16 @@ packages:
     version: 3.0.1
     dependencies:
       '@types/d3-selection': registry.npmjs.org/@types/d3-selection/3.0.3
-    dev: false
 
   registry.npmjs.org/@types/d3-chord/3.0.1:
     resolution: {integrity: sha512-eQfcxIHrg7V++W8Qxn6QkqBNBokyhdWSAS73AbkbMzvLQmVVBviknoz2SRS/ZJdIOmhcmmdCRE/NFOm28Z1AMw==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.1.tgz}
     name: '@types/d3-chord'
     version: 3.0.1
-    dev: false
 
   registry.npmjs.org/@types/d3-color/3.1.0:
     resolution: {integrity: sha512-HKuicPHJuvPgCD+np6Se9MQvS6OCbJmOjGvylzMJRlDwUXjKTTXs6Pwgk79O09Vj/ho3u1ofXnhFOaEWWPrlwA==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.0.tgz}
     name: '@types/d3-color'
     version: 3.1.0
-    dev: false
 
   registry.npmjs.org/@types/d3-contour/3.0.1:
     resolution: {integrity: sha512-C3zfBrhHZvrpAAK3YXqLWVAGo87A4SvJ83Q/zVJ8rFWJdKejUnDYaWZPkA8K84kb2vDA/g90LTQAz7etXcgoQQ==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.1.tgz}
@@ -1417,19 +1453,16 @@ packages:
     dependencies:
       '@types/d3-array': registry.npmjs.org/@types/d3-array/3.0.3
       '@types/geojson': registry.npmjs.org/@types/geojson/7946.0.10
-    dev: false
 
   registry.npmjs.org/@types/d3-delaunay/6.0.1:
     resolution: {integrity: sha512-tLxQ2sfT0p6sxdG75c6f/ekqxjyYR0+LwPrsO1mbC9YDBzPJhs2HbJJRrn8Ez1DBoHRo2yx7YEATI+8V1nGMnQ==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.1.tgz}
     name: '@types/d3-delaunay'
     version: 6.0.1
-    dev: false
 
   registry.npmjs.org/@types/d3-dispatch/3.0.1:
     resolution: {integrity: sha512-NhxMn3bAkqhjoxabVJWKryhnZXXYYVQxaBnbANu0O94+O/nX9qSjrA1P1jbAQJxJf+VC72TxDX/YJcKue5bRqw==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.1.tgz}
     name: '@types/d3-dispatch'
     version: 3.0.1
-    dev: false
 
   registry.npmjs.org/@types/d3-drag/3.0.1:
     resolution: {integrity: sha512-o1Va7bLwwk6h03+nSM8dpaGEYnoIG19P0lKqlic8Un36ymh9NSkNFX1yiXMKNMx8rJ0Kfnn2eovuFaL6Jvj0zA==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.1.tgz}
@@ -1437,19 +1470,16 @@ packages:
     version: 3.0.1
     dependencies:
       '@types/d3-selection': registry.npmjs.org/@types/d3-selection/3.0.3
-    dev: false
 
   registry.npmjs.org/@types/d3-dsv/3.0.0:
     resolution: {integrity: sha512-o0/7RlMl9p5n6FQDptuJVMxDf/7EDEv2SYEO/CwdG2tr1hTfUVi0Iavkk2ax+VpaQ/1jVhpnj5rq1nj8vwhn2A==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.0.tgz}
     name: '@types/d3-dsv'
     version: 3.0.0
-    dev: false
 
   registry.npmjs.org/@types/d3-ease/3.0.0:
     resolution: {integrity: sha512-aMo4eaAOijJjA6uU+GIeW018dvy9+oH5Y2VPPzjjfxevvGQ/oRDs+tfYC9b50Q4BygRR8yE2QCLsrT0WtAVseA==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.0.tgz}
     name: '@types/d3-ease'
     version: 3.0.0
-    dev: false
 
   registry.npmjs.org/@types/d3-fetch/3.0.1:
     resolution: {integrity: sha512-toZJNOwrOIqz7Oh6Q7l2zkaNfXkfR7mFSJvGvlD/Ciq/+SQ39d5gynHJZ/0fjt83ec3WL7+u3ssqIijQtBISsw==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.1.tgz}
@@ -1457,19 +1487,16 @@ packages:
     version: 3.0.1
     dependencies:
       '@types/d3-dsv': registry.npmjs.org/@types/d3-dsv/3.0.0
-    dev: false
 
   registry.npmjs.org/@types/d3-force/3.0.3:
     resolution: {integrity: sha512-z8GteGVfkWJMKsx6hwC3SiTSLspL98VNpmvLpEFJQpZPq6xpA1I8HNBDNSpukfK0Vb0l64zGFhzunLgEAcBWSA==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.3.tgz}
     name: '@types/d3-force'
     version: 3.0.3
-    dev: false
 
   registry.npmjs.org/@types/d3-format/3.0.1:
     resolution: {integrity: sha512-5KY70ifCCzorkLuIkDe0Z9YTf9RR2CjBX1iaJG+rgM/cPP+sO+q9YdQ9WdhQcgPj1EQiJ2/0+yUkkziTG6Lubg==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.1.tgz}
     name: '@types/d3-format'
     version: 3.0.1
-    dev: false
 
   registry.npmjs.org/@types/d3-geo/3.0.2:
     resolution: {integrity: sha512-DbqK7MLYA8LpyHQfv6Klz0426bQEf7bRTvhMy44sNGVyZoWn//B0c+Qbeg8Osi2Obdc9BLLXYAKpyWege2/7LQ==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.0.2.tgz}
@@ -1477,13 +1504,11 @@ packages:
     version: 3.0.2
     dependencies:
       '@types/geojson': registry.npmjs.org/@types/geojson/7946.0.10
-    dev: false
 
   registry.npmjs.org/@types/d3-hierarchy/3.1.0:
     resolution: {integrity: sha512-g+sey7qrCa3UbsQlMZZBOHROkFqx7KZKvUpRzI/tAp/8erZWpYq7FgNKvYwebi2LaEiVs1klhUfd3WCThxmmWQ==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.0.tgz}
     name: '@types/d3-hierarchy'
     version: 3.1.0
-    dev: false
 
   registry.npmjs.org/@types/d3-interpolate/3.0.1:
     resolution: {integrity: sha512-jx5leotSeac3jr0RePOH1KdR9rISG91QIE4Q2PYTu4OymLTZfA3SrnURSLzKH48HmXVUru50b8nje4E79oQSQw==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.1.tgz}
@@ -1491,37 +1516,31 @@ packages:
     version: 3.0.1
     dependencies:
       '@types/d3-color': registry.npmjs.org/@types/d3-color/3.1.0
-    dev: false
 
   registry.npmjs.org/@types/d3-path/3.0.0:
     resolution: {integrity: sha512-0g/A+mZXgFkQxN3HniRDbXMN79K3CdTpLsevj+PXiTcb2hVyvkZUBg37StmgCQkaD84cUJ4uaDAWq7UJOQy2Tg==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/d3-path/-/d3-path-3.0.0.tgz}
     name: '@types/d3-path'
     version: 3.0.0
-    dev: false
 
   registry.npmjs.org/@types/d3-polygon/3.0.0:
     resolution: {integrity: sha512-D49z4DyzTKXM0sGKVqiTDTYr+DHg/uxsiWDAkNrwXYuiZVd9o9wXZIo+YsHkifOiyBkmSWlEngHCQme54/hnHw==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.0.tgz}
     name: '@types/d3-polygon'
     version: 3.0.0
-    dev: false
 
   registry.npmjs.org/@types/d3-quadtree/3.0.2:
     resolution: {integrity: sha512-QNcK8Jguvc8lU+4OfeNx+qnVy7c0VrDJ+CCVFS9srBo2GL9Y18CnIxBdTF3v38flrGy5s1YggcoAiu6s4fLQIw==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.2.tgz}
     name: '@types/d3-quadtree'
     version: 3.0.2
-    dev: false
 
   registry.npmjs.org/@types/d3-random/3.0.1:
     resolution: {integrity: sha512-IIE6YTekGczpLYo/HehAy3JGF1ty7+usI97LqraNa8IiDur+L44d0VOjAvFQWJVdZOJHukUJw+ZdZBlgeUsHOQ==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.1.tgz}
     name: '@types/d3-random'
     version: 3.0.1
-    dev: false
 
   registry.npmjs.org/@types/d3-scale-chromatic/3.0.0:
     resolution: {integrity: sha512-dsoJGEIShosKVRBZB0Vo3C8nqSDqVGujJU6tPznsBJxNJNwMF8utmS83nvCBKQYPpjCzaaHcrf66iTRpZosLPw==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.0.0.tgz}
     name: '@types/d3-scale-chromatic'
     version: 3.0.0
-    dev: false
 
   registry.npmjs.org/@types/d3-scale/4.0.2:
     resolution: {integrity: sha512-Yk4htunhPAwN0XGlIwArRomOjdoBFXC3+kCxK2Ubg7I9shQlVSJy/pG/Ht5ASN+gdMIalpk8TJ5xV74jFsetLA==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.2.tgz}
@@ -1529,13 +1548,11 @@ packages:
     version: 4.0.2
     dependencies:
       '@types/d3-time': registry.npmjs.org/@types/d3-time/3.0.0
-    dev: false
 
   registry.npmjs.org/@types/d3-selection/3.0.3:
     resolution: {integrity: sha512-Mw5cf6nlW1MlefpD9zrshZ+DAWL4IQ5LnWfRheW6xwsdaWOb6IRRu2H7XPAQcyXEx1D7XQWgdoKR83ui1/HlEA==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.3.tgz}
     name: '@types/d3-selection'
     version: 3.0.3
-    dev: false
 
   registry.npmjs.org/@types/d3-shape/3.1.0:
     resolution: {integrity: sha512-jYIYxFFA9vrJ8Hd4Se83YI6XF+gzDL1aC5DCsldai4XYYiVNdhtpGbA/GM6iyQ8ayhSp3a148LY34hy7A4TxZA==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.0.tgz}
@@ -1543,25 +1560,21 @@ packages:
     version: 3.1.0
     dependencies:
       '@types/d3-path': registry.npmjs.org/@types/d3-path/3.0.0
-    dev: false
 
   registry.npmjs.org/@types/d3-time-format/4.0.0:
     resolution: {integrity: sha512-yjfBUe6DJBsDin2BMIulhSHmr5qNR5Pxs17+oW4DoVPyVIXZ+m6bs7j1UVKP08Emv6jRmYrYqxYzO63mQxy1rw==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.0.tgz}
     name: '@types/d3-time-format'
     version: 4.0.0
-    dev: false
 
   registry.npmjs.org/@types/d3-time/3.0.0:
     resolution: {integrity: sha512-sZLCdHvBUcNby1cB6Fd3ZBrABbjz3v1Vm90nysCQ6Vt7vd6e/h9Lt7SiJUoEX0l4Dzc7P5llKyhqSi1ycSf1Hg==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.0.tgz}
     name: '@types/d3-time'
     version: 3.0.0
-    dev: false
 
   registry.npmjs.org/@types/d3-timer/3.0.0:
     resolution: {integrity: sha512-HNB/9GHqu7Fo8AQiugyJbv6ZxYz58wef0esl4Mv828w1ZKpAshw/uFWVDUcIB9KKFeFKoxS3cHY07FFgtTRZ1g==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.0.tgz}
     name: '@types/d3-timer'
     version: 3.0.0
-    dev: false
 
   registry.npmjs.org/@types/d3-transition/3.0.2:
     resolution: {integrity: sha512-jo5o/Rf+/u6uerJ/963Dc39NI16FQzqwOc54bwvksGAdVfvDrqDpVeq95bEvPtBwLCVZutAEyAtmSyEMxN7vxQ==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.2.tgz}
@@ -1569,7 +1582,6 @@ packages:
     version: 3.0.2
     dependencies:
       '@types/d3-selection': registry.npmjs.org/@types/d3-selection/3.0.3
-    dev: false
 
   registry.npmjs.org/@types/d3-zoom/3.0.1:
     resolution: {integrity: sha512-7s5L9TjfqIYQmQQEUcpMAcBOahem7TRoSO/+Gkz02GbMVuULiZzjF2BOdw291dbO2aNon4m2OdFsRGaCq2caLQ==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.1.tgz}
@@ -1578,7 +1590,6 @@ packages:
     dependencies:
       '@types/d3-interpolate': registry.npmjs.org/@types/d3-interpolate/3.0.1
       '@types/d3-selection': registry.npmjs.org/@types/d3-selection/3.0.3
-    dev: false
 
   registry.npmjs.org/@types/d3/7.4.0:
     resolution: {integrity: sha512-jIfNVK0ZlxcuRDKtRS/SypEyOQ6UHaFQBKv032X45VvxSJ6Yi5G9behy9h6tNTHTDGh5Vq+KbmBjUWLgY4meCA==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/d3/-/d3-7.4.0.tgz}
@@ -1615,7 +1626,6 @@ packages:
       '@types/d3-timer': registry.npmjs.org/@types/d3-timer/3.0.0
       '@types/d3-transition': registry.npmjs.org/@types/d3-transition/3.0.2
       '@types/d3-zoom': registry.npmjs.org/@types/d3-zoom/3.0.1
-    dev: false
 
   registry.npmjs.org/@types/estree/0.0.39:
     resolution: {integrity: sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz}
@@ -1633,7 +1643,6 @@ packages:
     resolution: {integrity: sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.10.tgz}
     name: '@types/geojson'
     version: 7946.0.10
-    dev: false
 
   registry.npmjs.org/@types/is-ci/3.0.0:
     resolution: {integrity: sha512-Q0Op0hdWbYd1iahB+IFNQcWXFq4O0Q5MwQP7uN0souuQ4rPg1vEYcnIOfr1gY+M+6rc8FGoRaBO1mOOvL29sEQ==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/is-ci/-/is-ci-3.0.0.tgz}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -230,7 +230,7 @@ importers:
       '@types/node': ^18.7.16
       '@types/react': ^18.0.19
       '@types/react-dom': ^18.0.6
-      classcat: ^5.0.3
+      classcat: ^5.0.4
       d3-drag: ^3.0.0
       d3-selection: ^3.0.0
       react: ^18.2.0


### PR DESCRIPTION
This PR add a `@reactflow/node-resizer` package that exports two components that can be used inside a custom node as a helper to resize a node:

## 1. `<NodeResizer />`

This component adds four handles (top-left, top-right, bottom-right and bottom-left) and four lines (top, right, bottom, left) to resize a node.

![Screenshot 2022-12-04 at 17 59 09](https://user-images.githubusercontent.com/2857535/205504580-439d3c4b-ffed-4328-a455-a9a206032b76.png)

Props:

```js
type NodeResizerProps = {
  nodeId: string;
  handleClassName?: string;
  handleStyle?: CSSProperties;
  lineClassName?: string;
  lineStyle?: CSSProperties;
};
```

## 2. `<NodeResizeControl />`

This component can be used for creating a custom resize UI.

![Screenshot 2022-12-04 at 17 59 43](https://user-images.githubusercontent.com/2857535/205504590-4ddb6fa6-576b-44b4-bc01-66c67bc62ae9.png)

Props: 

```js
type ResizeControlProps = {
  nodeId: string;
  position: ControlPosition;
  variant?: ResizeControlVariant;
  className?: string;
  style?: CSSProperties;
  children?: ReactNode;
};
```
