### PR TITLE
Assign the random root id by default

### DIFF
--- a/examples/vite-app/cypress/components/reactflow/multiple-instance.cy.tsx
+++ b/examples/vite-app/cypress/components/reactflow/multiple-instance.cy.tsx
@@ -1,4 +1,11 @@
-import ReactFlow, { BaseEdge, EdgeLabelRenderer, EdgeProps, getSmoothStepPath, ReactFlowProvider } from 'reactflow';
+import ReactFlow, {
+  Background,
+  BaseEdge,
+  EdgeLabelRenderer,
+  EdgeProps,
+  getSmoothStepPath,
+  ReactFlowProvider,
+} from 'reactflow';
 import * as simpleflow from '../../fixtures/simpleflow';
 
 function CustomEdge(props: EdgeProps) {
@@ -57,6 +64,33 @@ describe('<ReactFlow />: Multiple Instances', () => {
         .eq(1)
         .within(() => {
           cy.get('.label').should('have.length', 1).should('contain.text', 'edge2');
+        });
+    });
+  });
+
+  describe('<Background>', () => {
+    beforeEach(() => {
+      cy.mount(
+        <>
+          <ReactFlowProvider>
+            <ReactFlow defaultNodes={simpleflow1.nodes} defaultEdges={simpleflow1.edges}>
+              <Background />
+            </ReactFlow>
+          </ReactFlowProvider>
+          <ReactFlowProvider>
+            <ReactFlow defaultNodes={simpleflow2.nodes} defaultEdges={simpleflow2.edges}>
+              <Background />
+            </ReactFlow>
+          </ReactFlowProvider>
+        </>
+      );
+    });
+
+    it("The background pattern's IDs should not be the same", () => {
+      cy.get('.react-flow__background pattern')
+        .should('have.length', 2)
+        .spread((pattern1, pattern2) => {
+          cy.wrap(pattern1.getAttribute('id')).should('not.eq', pattern2.getAttribute('id'));
         });
     });
   });

--- a/packages/core/src/container/ReactFlow/index.tsx
+++ b/packages/core/src/container/ReactFlow/index.tsx
@@ -28,6 +28,7 @@ import type {
   ReactFlowRefType,
   Viewport,
 } from '../../types';
+import { getPrefixId } from '../../utils';
 
 const defaultNodeTypes: NodeTypes = {
   input: InputNode,
@@ -162,7 +163,7 @@ const ReactFlow = forwardRef<ReactFlowRefType, ReactFlowProps>(
   ) => {
     const nodeTypesWrapped = useNodeOrEdgeTypes(nodeTypes, createNodeTypes) as NodeTypesWrapped;
     const edgeTypesWrapped = useNodeOrEdgeTypes(edgeTypes, createEdgeTypes) as EdgeTypesWrapped;
-    const rfId = id || '1';
+    const rfId = id || getPrefixId();
 
     return (
       <div

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -69,3 +69,7 @@ export const devWarn = (message: string) => {
     console.warn(`[React Flow]: ${message}`);
   }
 };
+
+export const getPrefixId = () => {
+  return (Math.random() * 1e15).toString(36).replace(".", '_')
+}


### PR DESCRIPTION
When there are multiple flows on a page, the developer needs to specify a unique ID for each flow; otherwise, an issue will appear like [#2546](https://github.com/wbkd/react-flow/issues/2546).

The commit assigns a unique random ID by default so that the developer can ignore the ID property.

The [commit](https://github.com/wbkd/react-flow-docs/commit/beabb9ee161e098801a36368890be12caeefade9) can be reversed too.