### PR TITLE
Check both handle types in EdgeRenderer if ConnectionType is Loose

### DIFF
--- a/packages/core/src/container/EdgeRenderer/index.tsx
+++ b/packages/core/src/container/EdgeRenderer/index.tsx
@@ -116,7 +116,7 @@ const EdgeRenderer = (props: EdgeRendererProps) => {
               const targetNodeHandles =
                 connectionMode === ConnectionMode.Strict
                   ? targetHandleBounds!.target
-                  : targetHandleBounds!.target || targetHandleBounds!.source;
+                  : (targetHandleBounds!.target ?? []).concat(targetHandleBounds!.source ?? []);
               const sourceHandle = getHandle(sourceHandleBounds!.source!, edge.sourceHandle || null);
               const targetHandle = getHandle(targetNodeHandles!, edge.targetHandle || null);
               const sourcePosition = sourceHandle?.position || Position.Bottom;


### PR DESCRIPTION
Fixes #2630 by concatenating both handle types instead of only looking at targets if any exist. The initial behavior does not change, as targets get chosen preferentially if no handle id is given. This applies only to `ConnectionType.Loose`