### PR TITLE
fix(usedrag): block onNodeDragStop when user just click node

### DIFF
--- a/packages/core/src/hooks/useDrag/index.ts
+++ b/packages/core/src/hooks/useDrag/index.ts
@@ -48,6 +48,7 @@ function useDrag({
       if (disabled) {
         selection.on('.drag', null);
       } else {
+        let isMoved = false
         const dragHandler = drag()
           .on('start', (event: UseDragEvent) => {
             const {
@@ -88,6 +89,7 @@ function useDrag({
             }
           })
           .on('drag', (event: UseDragEvent) => {
+            isMoved = true
             const {
               updateNodePositions,
               nodeInternals,
@@ -154,7 +156,8 @@ function useDrag({
             setDragging(false);
             if (dragItems.current) {
               const { updateNodePositions, nodeInternals, onNodeDragStop, onSelectionDragStop } = store.getState();
-              const onStop = nodeId ? onNodeDragStop : wrapSelectionDragFunc(onSelectionDragStop);
+
+              const onStop = (nodeId && isMoved) ? onNodeDragStop : wrapSelectionDragFunc(onSelectionDragStop);
 
               updateNodePositions(dragItems.current, false, false);
 


### PR DESCRIPTION
this PR is useful for #2622

When I want to create a solution to autosave flow's change for my project, I find that onNodeDragStop will be call when I just click a node, that's not I want to see. So I search in issues, and just find #2622(still open), there is no simple solution to this problem without change source. After I looked at the source about onNodeDragStop I found that the solution to this problem maybe actually very simple, just add a variable to determine whether to drag or not. So I fix it and push this PR.

I hope it is useful.