### PR TITLE
Backported EdgeLabelRenderer to v10 branch.

### DIFF
--- a/src/components/EdgeLabelRenderer/index.tsx
+++ b/src/components/EdgeLabelRenderer/index.tsx
@@ -1,0 +1,18 @@
+import type { ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+import { useStore } from '../../store';
+import { ReactFlowState } from '../../types';
+
+const selector = (s: ReactFlowState) => s.domNode?.querySelector('.react-flow__edgelabel-renderer');
+
+function EdgeLabelRenderer({ children }: { children: ReactNode }) {
+  const edgeLabelRenderer = useStore(selector);
+
+  if (!edgeLabelRenderer) {
+    return null;
+  }
+
+  return createPortal(children, edgeLabelRenderer);
+}
+
+export default EdgeLabelRenderer;

--- a/src/container/GraphView/index.tsx
+++ b/src/container/GraphView/index.tsx
@@ -149,6 +149,8 @@ const GraphView = ({
           elevateEdgesOnSelect={!!elevateEdgesOnSelect}
           rfId={id}
         />
+        <div className="react-flow__edgelabel-renderer" />
+
         <NodeRenderer
           nodeTypes={nodeTypes}
           onNodeClick={onNodeClick}

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ export {
 } from './utils/graph';
 export { applyNodeChanges, applyEdgeChanges } from './utils/changes';
 export { getMarkerEnd, getCenter as getEdgeCenter } from './components/Edges/utils';
+export { default as EdgeLabelRenderer } from './components/EdgeLabelRenderer';
 
 export { default as useReactFlow } from './hooks/useReactFlow';
 export { default as useUpdateNodeInternals } from './hooks/useUpdateNodeInternals';

--- a/src/style.css
+++ b/src/style.css
@@ -204,3 +204,10 @@
     transform: translateX(-50%);
   }
 }
+
+.react-flow__edgelabel-renderer {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}


### PR DESCRIPTION
As mentioned in https://github.com/wbkd/react-flow/discussions/2725, I'm interested in being able to use the `EdgeLabelRenderer` component in React Flow v10. I've done what I believe is necessary to make it available based on previous PRs. Please let me know if I should make any changes!