### PR TITLE
Node-resizer: add shouldResize handler

### DIFF
--- a/.changeset/pretty-spoons-punch.md
+++ b/.changeset/pretty-spoons-punch.md
@@ -1,0 +1,5 @@
+---
+'@reactflow/node-resizer': major
+---
+
+Add shouldresize, cleanup types

--- a/examples/vite-app/src/examples/NodeResizer/CustomResizer.tsx
+++ b/examples/vite-app/src/examples/NodeResizer/CustomResizer.tsx
@@ -1,7 +1,7 @@
-import { memo, FC, CSSProperties } from 'react';
+import { memo, FC } from 'react';
 import { Handle, Position, NodeProps } from 'reactflow';
 
-import { NodeResizer, NodeResizeControl } from '@reactflow/node-resizer';
+import { NodeResizeControl } from '@reactflow/node-resizer';
 import '@reactflow/node-resizer/dist/style.css';
 import ResizeIcon from './ResizeIcon';
 

--- a/examples/vite-app/src/examples/NodeResizer/CustomResizer2.tsx
+++ b/examples/vite-app/src/examples/NodeResizer/CustomResizer2.tsx
@@ -1,14 +1,14 @@
 import { memo, FC } from 'react';
 import { Handle, Position, NodeProps } from 'reactflow';
 
-import { NodeResizer, NodeResizeControl } from '@reactflow/node-resizer';
+import { NodeResizeControl } from '@reactflow/node-resizer';
 import '@reactflow/node-resizer/dist/style.css';
 
 const CustomNode: FC<NodeProps> = ({ id, data }) => {
   return (
     <>
-      <NodeResizeControl color="red" position="top" />
-      <NodeResizeControl color="red" position="bottom" />
+      <NodeResizeControl color="red" position={Position.Top} />
+      <NodeResizeControl color="red" position={Position.Bottom} />
       <Handle type="target" position={Position.Left} />
       <div style={{ padding: 10 }}>{data.label}</div>
       <Handle type="source" position={Position.Right} />

--- a/examples/vite-app/src/examples/NodeResizer/CustomResizer3.tsx
+++ b/examples/vite-app/src/examples/NodeResizer/CustomResizer3.tsx
@@ -1,0 +1,31 @@
+import { memo, FC } from 'react';
+import { Handle, Position, NodeProps } from 'reactflow';
+
+import { NodeResizeControl, ResizeDragEvent, ResizeEventParams } from '@reactflow/node-resizer';
+import '@reactflow/node-resizer/dist/style.css';
+
+const onBeforeResize = (event: ResizeDragEvent, params: ResizeEventParams) => {
+  console.log('before resize', params);
+
+  if (params.width > 100) {
+    return false;
+  }
+};
+
+const onResize = (event: ResizeDragEvent, params: ResizeEventParams) => {
+  console.log('resize', params);
+};
+
+const CustomNode: FC<NodeProps> = ({ id, data }) => {
+  return (
+    <>
+      <NodeResizeControl color="red" position={Position.Left} />
+      <NodeResizeControl color="red" position={Position.Right} onBeforeResize={onBeforeResize} onResize={onResize} />
+      <Handle type="target" position={Position.Top} />
+      <div style={{ padding: 10 }}>{data.label}</div>
+      <Handle type="source" position={Position.Bottom} />
+    </>
+  );
+};
+
+export default memo(CustomNode);

--- a/examples/vite-app/src/examples/NodeResizer/CustomResizer3.tsx
+++ b/examples/vite-app/src/examples/NodeResizer/CustomResizer3.tsx
@@ -1,15 +1,17 @@
 import { memo, FC } from 'react';
 import { Handle, Position, NodeProps } from 'reactflow';
 
-import { NodeResizeControl, OnResize, OnBeforeResize } from '@reactflow/node-resizer';
+import { NodeResizeControl, OnResize, ShouldResize } from '@reactflow/node-resizer';
 import '@reactflow/node-resizer/dist/style.css';
 
-const onBeforeResize: OnBeforeResize = (event, params) => {
+const shouldResize: ShouldResize = (event, params) => {
   console.log('before resize', params);
 
   if (params.width > 100) {
     return false;
   }
+
+  return true;
 };
 
 const onResize: OnResize = (event, params) => {
@@ -20,7 +22,7 @@ const CustomNode: FC<NodeProps> = ({ id, data }) => {
   return (
     <>
       <NodeResizeControl color="red" position={Position.Left} />
-      <NodeResizeControl color="red" position={Position.Right} onBeforeResize={onBeforeResize} onResize={onResize} />
+      <NodeResizeControl color="red" position={Position.Right} shouldResize={shouldResize} onResize={onResize} />
       <Handle type="target" position={Position.Top} />
       <div style={{ padding: 10 }}>{data.label}</div>
       <Handle type="source" position={Position.Bottom} />

--- a/examples/vite-app/src/examples/NodeResizer/CustomResizer3.tsx
+++ b/examples/vite-app/src/examples/NodeResizer/CustomResizer3.tsx
@@ -1,10 +1,10 @@
 import { memo, FC } from 'react';
 import { Handle, Position, NodeProps } from 'reactflow';
 
-import { NodeResizeControl, ResizeDragEvent, ResizeEventParams } from '@reactflow/node-resizer';
+import { NodeResizeControl, OnResize, OnBeforeResize } from '@reactflow/node-resizer';
 import '@reactflow/node-resizer/dist/style.css';
 
-const onBeforeResize = (event: ResizeDragEvent, params: ResizeEventParams) => {
+const onBeforeResize: OnBeforeResize = (event, params) => {
   console.log('before resize', params);
 
   if (params.width > 100) {
@@ -12,8 +12,8 @@ const onBeforeResize = (event: ResizeDragEvent, params: ResizeEventParams) => {
   }
 };
 
-const onResize = (event: ResizeDragEvent, params: ResizeEventParams) => {
-  console.log('resize', params);
+const onResize: OnResize = (event, params) => {
+  console.log('resize', params.direction);
 };
 
 const CustomNode: FC<NodeProps> = ({ id, data }) => {

--- a/examples/vite-app/src/examples/NodeResizer/NodeResizerNode.tsx
+++ b/examples/vite-app/src/examples/NodeResizer/NodeResizerNode.tsx
@@ -1,15 +1,11 @@
 import { memo, FC } from 'react';
 import { Handle, Position, NodeProps } from 'reactflow';
 
-import { NodeResizer, OnBeforeResize, OnResize, OnResizeEnd, OnResizeStart } from '@reactflow/node-resizer';
+import { NodeResizer, ShouldResize, OnResize, OnResizeEnd, OnResizeStart } from '@reactflow/node-resizer';
 import '@reactflow/node-resizer/dist/style.css';
 
 const onResizeStart: OnResizeStart = (_, params) => {
   console.log('resize start', params);
-};
-
-const onBeforeResize: OnBeforeResize = (_, params) => {
-  console.log('before resize', params);
 };
 
 const onResize: OnResize = (_, params) => {
@@ -20,6 +16,12 @@ const onResizeEnd: OnResizeEnd = (_, params) => {
   console.log('resize end', params);
 };
 
+const shouldResize: ShouldResize = (_, params) => {
+  console.log('should resize', params);
+
+  return true;
+};
+
 const CustomNode: FC<NodeProps> = ({ data, selected }) => {
   return (
     <>
@@ -27,8 +29,8 @@ const CustomNode: FC<NodeProps> = ({ data, selected }) => {
         minWidth={100}
         minHeight={100}
         isVisible={selected}
+        shouldResize={shouldResize}
         onResizeStart={onResizeStart}
-        onBeforeResize={onBeforeResize}
         onResize={onResize}
         onResizeEnd={onResizeEnd}
       />

--- a/examples/vite-app/src/examples/NodeResizer/NodeResizerNode.tsx
+++ b/examples/vite-app/src/examples/NodeResizer/NodeResizerNode.tsx
@@ -1,22 +1,22 @@
 import { memo, FC } from 'react';
 import { Handle, Position, NodeProps } from 'reactflow';
 
-import { NodeResizer, ResizeDragEvent, ResizeEventParams } from '@reactflow/node-resizer';
+import { NodeResizer, OnBeforeResize, OnResize, OnResizeEnd, OnResizeStart } from '@reactflow/node-resizer';
 import '@reactflow/node-resizer/dist/style.css';
 
-const onResizeStart = (_: ResizeDragEvent, params: ResizeEventParams) => {
+const onResizeStart: OnResizeStart = (_, params) => {
   console.log('resize start', params);
 };
 
-const onBeforeResize = (_: ResizeDragEvent, params: ResizeEventParams) => {
+const onBeforeResize: OnBeforeResize = (_, params) => {
   console.log('before resize', params);
 };
 
-const onResize = (_: ResizeDragEvent, params: ResizeEventParams) => {
+const onResize: OnResize = (_, params) => {
   console.log('resize', params);
 };
 
-const onResizeEnd = (_: ResizeDragEvent, params: ResizeEventParams) => {
+const onResizeEnd: OnResizeEnd = (_, params) => {
   console.log('resize end', params);
 };
 

--- a/examples/vite-app/src/examples/NodeResizer/NodeResizerNode.tsx
+++ b/examples/vite-app/src/examples/NodeResizer/NodeResizerNode.tsx
@@ -8,6 +8,10 @@ const onResizeStart = (_: ResizeDragEvent, params: ResizeEventParams) => {
   console.log('resize start', params);
 };
 
+const onBeforeResize = (_: ResizeDragEvent, params: ResizeEventParams) => {
+  console.log('before resize', params);
+};
+
 const onResize = (_: ResizeDragEvent, params: ResizeEventParams) => {
   console.log('resize', params);
 };
@@ -24,6 +28,7 @@ const CustomNode: FC<NodeProps> = ({ data, selected }) => {
         minHeight={100}
         isVisible={selected}
         onResizeStart={onResizeStart}
+        onBeforeResize={onBeforeResize}
         onResize={onResize}
         onResizeEnd={onResizeEnd}
       />

--- a/examples/vite-app/src/examples/NodeResizer/index.tsx
+++ b/examples/vite-app/src/examples/NodeResizer/index.tsx
@@ -4,11 +4,13 @@ import ReactFlow, { Controls, addEdge, Position, Connection, useNodesState, useE
 import NodeResizerNode from './NodeResizerNode';
 import CustomResizer from './CustomResizer';
 import CustomResizer2 from './CustomResizer2';
+import CustomResizer3 from './CustomResizer3';
 
 const nodeTypes = {
   resizer: NodeResizerNode,
   customResizer: CustomResizer,
   customResizer2: CustomResizer2,
+  customResizer3: CustomResizer3,
 };
 
 const initialEdges = [
@@ -60,6 +62,13 @@ const initialNodes = [
     position: { x: 250, y: 250 },
     style: { border: '1px solid #222', fontSize: 10 },
   },
+  {
+    id: '6',
+    type: 'customResizer3',
+    data: { label: 'resize controls' },
+    position: { x: 400, y: 200 },
+    style: { border: '1px solid #222', fontSize: 10 },
+  },
 ];
 
 const CustomNodeFlow = () => {
@@ -87,7 +96,7 @@ const CustomNodeFlow = () => {
     >
       <Controls />
       <Panel position="bottom-right">
-        <button onClick={() => setSnapToGrid(!snapToGrid)}>snapToGrid: {snapToGrid ? 'on' : 'off'}</button>
+        <button onClick={() => setSnapToGrid((s) => !s)}>snapToGrid: {snapToGrid ? 'on' : 'off'}</button>
       </Panel>
     </ReactFlow>
   );

--- a/packages/node-resizer/package.json
+++ b/packages/node-resizer/package.json
@@ -38,7 +38,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@reactflow/core": "workspace:*",
+    "@reactflow/core": "workspace:^11.3.3",
     "classcat": "^5.0.4",
     "d3-drag": "^3.0.0",
     "d3-selection": "^3.0.0",

--- a/packages/node-resizer/src/NodeResizer.tsx
+++ b/packages/node-resizer/src/NodeResizer.tsx
@@ -15,6 +15,7 @@ export default function NodeResizer({
   minWidth = 10,
   minHeight = 10,
   onResizeStart,
+  onBeforeResize,
   onResize,
   onResizeEnd,
 }: NodeResizerProps) {
@@ -36,6 +37,7 @@ export default function NodeResizer({
           minWidth={minWidth}
           minHeight={minHeight}
           onResizeStart={onResizeStart}
+          onBeforeResize={onBeforeResize}
           onResize={onResize}
           onResizeEnd={onResizeEnd}
         />
@@ -51,6 +53,7 @@ export default function NodeResizer({
           minWidth={minWidth}
           minHeight={minHeight}
           onResizeStart={onResizeStart}
+          onBeforeResize={onBeforeResize}
           onResize={onResize}
           onResizeEnd={onResizeEnd}
         />

--- a/packages/node-resizer/src/NodeResizer.tsx
+++ b/packages/node-resizer/src/NodeResizer.tsx
@@ -14,8 +14,8 @@ export default function NodeResizer({
   color,
   minWidth = 10,
   minHeight = 10,
+  shouldResize,
   onResizeStart,
-  onBeforeResize,
   onResize,
   onResizeEnd,
 }: NodeResizerProps) {
@@ -37,7 +37,7 @@ export default function NodeResizer({
           minWidth={minWidth}
           minHeight={minHeight}
           onResizeStart={onResizeStart}
-          onBeforeResize={onBeforeResize}
+          shouldResize={shouldResize}
           onResize={onResize}
           onResizeEnd={onResizeEnd}
         />
@@ -53,7 +53,7 @@ export default function NodeResizer({
           minWidth={minWidth}
           minHeight={minHeight}
           onResizeStart={onResizeStart}
-          onBeforeResize={onBeforeResize}
+          shouldResize={shouldResize}
           onResize={onResize}
           onResizeEnd={onResizeEnd}
         />

--- a/packages/node-resizer/src/ResizeControl.tsx
+++ b/packages/node-resizer/src/ResizeControl.tsx
@@ -12,6 +12,7 @@ import {
 } from '@reactflow/core';
 
 import { ResizeDragEvent, ResizeControlProps, ResizeControlLineProps, ResizeControlVariant } from './types';
+import { getDirection } from './utils';
 
 const initPrevValues = { width: 0, height: 0, x: 0, y: 0 };
 
@@ -99,7 +100,6 @@ function ResizeControl({
           const height = Math.max(startHeight + (invertY ? -distY : distY), minHeight);
           const isWidthChange = width !== prevWidth;
           const isHeightChange = height !== prevHeight;
-          const onBeforeResizeResult = onBeforeResize?.(event, { ...prevValues.current });
 
           if (invertX || invertY) {
             const x = invertX ? startNodeX - (width - startWidth) : startNodeX;
@@ -141,11 +141,27 @@ function ResizeControl({
             prevValues.current.width = width;
             prevValues.current.height = height;
           }
+
+          if (changes.length === 0) {
+            return;
+          }
+
+          const onBeforeResizeResult = onBeforeResize?.(event, { ...prevValues.current });
+
           if (onBeforeResizeResult === false) {
             return;
           }
 
-          onResize?.(event, { ...prevValues.current });
+          const direction = getDirection({
+            width: prevValues.current.width,
+            prevWidth,
+            height: prevValues.current.height,
+            prevHeight,
+            invertX,
+            invertY,
+          });
+
+          onResize?.(event, { ...prevValues.current, direction });
           triggerNodeChanges(changes);
         }
       })

--- a/packages/node-resizer/src/ResizeControl.tsx
+++ b/packages/node-resizer/src/ResizeControl.tsx
@@ -32,6 +32,7 @@ function ResizeControl({
   minWidth = 10,
   minHeight = 10,
   onResizeStart,
+  onBeforeResize,
   onResize,
   onResizeEnd,
 }: ResizeControlProps) {
@@ -98,6 +99,7 @@ function ResizeControl({
           const height = Math.max(startHeight + (invertY ? -distY : distY), minHeight);
           const isWidthChange = width !== prevWidth;
           const isHeightChange = height !== prevHeight;
+          const onBeforeResizeResult = onBeforeResize?.(event, { ...prevValues.current });
 
           if (invertX || invertY) {
             const x = invertX ? startNodeX - (width - startWidth) : startNodeX;
@@ -138,6 +140,9 @@ function ResizeControl({
             changes.push(dimensionChange);
             prevValues.current.width = width;
             prevValues.current.height = height;
+          }
+          if (onBeforeResizeResult === false) {
+            return;
           }
 
           onResize?.(event, { ...prevValues.current });

--- a/packages/node-resizer/src/ResizeControl.tsx
+++ b/packages/node-resizer/src/ResizeControl.tsx
@@ -32,8 +32,8 @@ function ResizeControl({
   color,
   minWidth = 10,
   minHeight = 10,
+  shouldResize,
   onResizeStart,
-  onBeforeResize,
   onResize,
   onResizeEnd,
 }: ResizeControlProps) {
@@ -146,12 +146,6 @@ function ResizeControl({
             return;
           }
 
-          const onBeforeResizeResult = onBeforeResize?.(event, { ...prevValues.current });
-
-          if (onBeforeResizeResult === false) {
-            return;
-          }
-
           const direction = getDirection({
             width: prevValues.current.width,
             prevWidth,
@@ -161,7 +155,15 @@ function ResizeControl({
             invertY,
           });
 
-          onResize?.(event, { ...prevValues.current, direction });
+          const nextValues = { ...prevValues.current, direction };
+
+          const callResize = shouldResize?.(event, nextValues);
+
+          if (callResize === false) {
+            return;
+          }
+
+          onResize?.(event, nextValues);
           triggerNodeChanges(changes);
         }
       })

--- a/packages/node-resizer/src/types.ts
+++ b/packages/node-resizer/src/types.ts
@@ -1,12 +1,23 @@
 import type { CSSProperties, ReactNode } from 'react';
 import type { D3DragEvent, SubjectPosition } from 'd3-drag';
 
-export type ResizeEventParams = {
+export type ResizeParams = {
   x: number;
   y: number;
   width: number;
   height: number;
 };
+
+export type ResizeParamsWithDirection = ResizeParams & {
+  direction: number[];
+};
+
+type OnResizeHandler<Params = ResizeParams, Result = void> = (event: ResizeDragEvent, params: Params) => Result;
+
+export type OnResizeStart = OnResizeHandler;
+export type OnBeforeResize = OnResizeHandler<ResizeParams, unknown>;
+export type OnResize = OnResizeHandler<ResizeParamsWithDirection>;
+export type OnResizeEnd = OnResizeHandler;
 
 export type NodeResizerProps = {
   nodeId?: string;
@@ -18,10 +29,10 @@ export type NodeResizerProps = {
   isVisible?: boolean;
   minWidth?: number;
   minHeight?: number;
-  onResizeStart?: (event: ResizeDragEvent, params: ResizeEventParams) => void;
-  onBeforeResize?: (event: ResizeDragEvent, params: ResizeEventParams) => unknown;
-  onResize?: (event: ResizeDragEvent, params: ResizeEventParams) => void;
-  onResizeEnd?: (event: ResizeDragEvent, params: ResizeEventParams) => void;
+  onResizeStart?: OnResizeStart;
+  onBeforeResize?: OnBeforeResize;
+  onResize?: OnResize;
+  onResizeEnd?: OnResizeEnd;
 };
 
 export type ControlLinePosition = 'top' | 'bottom' | 'left' | 'right';

--- a/packages/node-resizer/src/types.ts
+++ b/packages/node-resizer/src/types.ts
@@ -14,8 +14,8 @@ export type ResizeParamsWithDirection = ResizeParams & {
 
 type OnResizeHandler<Params = ResizeParams, Result = void> = (event: ResizeDragEvent, params: Params) => Result;
 
+export type ShouldResize = OnResizeHandler<ResizeParamsWithDirection, boolean>;
 export type OnResizeStart = OnResizeHandler;
-export type OnBeforeResize = OnResizeHandler<ResizeParams, unknown>;
 export type OnResize = OnResizeHandler<ResizeParamsWithDirection>;
 export type OnResizeEnd = OnResizeHandler;
 
@@ -29,8 +29,8 @@ export type NodeResizerProps = {
   isVisible?: boolean;
   minWidth?: number;
   minHeight?: number;
+  shouldResize?: ShouldResize;
   onResizeStart?: OnResizeStart;
-  onBeforeResize?: OnBeforeResize;
   onResize?: OnResize;
   onResizeEnd?: OnResizeEnd;
 };
@@ -46,7 +46,7 @@ export enum ResizeControlVariant {
 
 export type ResizeControlProps = Pick<
   NodeResizerProps,
-  'nodeId' | 'color' | 'minWidth' | 'minHeight' | 'onResizeStart' | 'onBeforeResize' | 'onResize' | 'onResizeEnd'
+  'nodeId' | 'color' | 'minWidth' | 'minHeight' | 'shouldResize' | 'onResizeStart' | 'onResize' | 'onResizeEnd'
 > & {
   position?: ControlPosition;
   variant?: ResizeControlVariant;

--- a/packages/node-resizer/src/types.ts
+++ b/packages/node-resizer/src/types.ts
@@ -19,6 +19,7 @@ export type NodeResizerProps = {
   minWidth?: number;
   minHeight?: number;
   onResizeStart?: (event: ResizeDragEvent, params: ResizeEventParams) => void;
+  onBeforeResize?: (event: ResizeDragEvent, params: ResizeEventParams) => unknown;
   onResize?: (event: ResizeDragEvent, params: ResizeEventParams) => void;
   onResizeEnd?: (event: ResizeDragEvent, params: ResizeEventParams) => void;
 };
@@ -34,7 +35,7 @@ export enum ResizeControlVariant {
 
 export type ResizeControlProps = Pick<
   NodeResizerProps,
-  'nodeId' | 'color' | 'minWidth' | 'minHeight' | 'onResizeStart' | 'onResize' | 'onResizeEnd'
+  'nodeId' | 'color' | 'minWidth' | 'minHeight' | 'onResizeStart' | 'onBeforeResize' | 'onResize' | 'onResizeEnd'
 > & {
   position?: ControlPosition;
   variant?: ResizeControlVariant;

--- a/packages/node-resizer/src/utils.ts
+++ b/packages/node-resizer/src/utils.ts
@@ -1,0 +1,26 @@
+type GetDirectionParams = {
+  width: number;
+  prevWidth: number;
+  height: number;
+  prevHeight: number;
+  invertX: boolean;
+  invertY: boolean;
+};
+
+// returns an array of two numbers (0, 1 or -1) representing the direction of the resize
+// 0 = no change, 1 = increase, -1 = decrease
+export function getDirection({ width, prevWidth, height, prevHeight, invertX, invertY }: GetDirectionParams) {
+  const deltaWidth = width - prevWidth;
+  const deltaHeight = height - prevHeight;
+
+  const direction = [deltaWidth > 0 ? 1 : deltaWidth < 0 ? -1 : 0, deltaHeight > 0 ? 1 : deltaHeight < 0 ? -1 : 0];
+
+  if (deltaWidth && invertX) {
+    direction[0] = direction[0] * -1;
+  }
+
+  if (deltaHeight && invertY) {
+    direction[1] = direction[1] * -1;
+  }
+  return direction;
+}

--- a/packages/node-toolbar/package.json
+++ b/packages/node-toolbar/package.json
@@ -36,7 +36,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@reactflow/core": "workspace:*",
+    "@reactflow/core": "workspace:^11.3.3",
     "classcat": "^5.0.3",
     "zustand": "^4.3.1"
   },


### PR DESCRIPTION
Two improvements are planned for the node resizer:

1. Add an ~`onBeforeResize`~  `shouldResize` handler that returns a boolean. This can be helpful to implement dimensions constraints that are based on other nodes for example.

```js
const shouldResize = (event, params) => {
 return params.width < 100;
}
```

2. Add a `direction` attribute to the passed params in the event handlers. This is helpful if your calculations are different based on the direction where a resize movement comes from. Not sure how this could look like. Maybe [1, 0] for a movement to the right, [0, -1] to the top, [1, 1] to the bottom right and so forth?