### PR TITLE
Pass actual node type

### DIFF
--- a/packages/core/src/container/NodeRenderer/index.tsx
+++ b/packages/core/src/container/NodeRenderer/index.tsx
@@ -109,7 +109,7 @@ const NodeRenderer = (props: NodeRendererProps) => {
             id={node.id}
             className={node.className}
             style={node.style}
-            type={nodeType}
+            type={node.type}
             data={node.data}
             sourcePosition={node.sourcePosition || Position.Bottom}
             targetPosition={node.targetPosition || Position.Top}


### PR DESCRIPTION
In my application I have have node of different types. Not all of them have their specific `ComponentType`.
So I specify "default" node type. But in this case I dont have access to node type because it is being overwritten with `"default"` string.