### PR TITLE
fix non-passive wheel event listener violation

### DIFF
--- a/packages/core/src/container/ZoomPane/index.tsx
+++ b/packages/core/src/container/ZoomPane/index.tsx
@@ -140,7 +140,7 @@ const ZoomPane = ({
             -(deltaX / currentZoom) * panOnScrollSpeed,
             -(deltaY / currentZoom) * panOnScrollSpeed
           );
-        });
+        }, { passive: false });
       } else if (typeof d3ZoomHandler !== 'undefined') {
         d3Selection.on('wheel.zoom', function (event: any, d: any) {
           if (!preventScrolling || isWrappedWithClass(event, noWheelClassName)) {
@@ -149,7 +149,7 @@ const ZoomPane = ({
 
           event.preventDefault();
           d3ZoomHandler.call(this, event, d);
-        });
+        }, { passive: false });
       }
     }
   }, [


### PR DESCRIPTION
This fixes Chrome warning about non-passive wheel event listener by explicitly setting passive to false (which suppresses the warning). Fixes #546, fixes #1688.

```
[Violation] Added non-passive event listener to a scroll-blocking 'wheel' event. Consider marking event handler as 'passive' to make the page more responsive. See https://www.chromestatus.com/feature/5745543795965952
```

To reproduce the issue, open https://reactflow.dev in latest Chrome version and check the console for warnings (it could be required to reload the page with console opened).