### PR TITLE
add twin lines background variant

### DIFF
--- a/examples/vite-app/src/examples/Backgrounds/index.tsx
+++ b/examples/vite-app/src/examples/Backgrounds/index.tsx
@@ -36,6 +36,7 @@ const Backgrounds: FC = () => (
     <Flow id="flow-a" bgProps={{ variant: BackgroundVariant.Dots }} />
     <Flow id="flow-b" bgProps={{ variant: BackgroundVariant.Lines, gap: [50, 50] }} />
     <Flow id="flow-c" bgProps={{ variant: BackgroundVariant.Cross, gap: [100, 50] }} />
+    <Flow id="flow-d" bgProps={{ variant: BackgroundVariant.TwinLines }} />
   </div>
 );
 

--- a/packages/background/src/Background.tsx
+++ b/packages/background/src/Background.tsx
@@ -9,18 +9,33 @@ import { DotPattern, LinePattern } from './Patterns';
 const defaultColor = {
   [BackgroundVariant.Dots]: '#91919a',
   [BackgroundVariant.Lines]: '#eee',
+  [BackgroundVariant.TwinLines]: '#ccc',
   [BackgroundVariant.Cross]: '#e2e2e2',
 };
 
 const defaultSize = {
   [BackgroundVariant.Dots]: 1,
   [BackgroundVariant.Lines]: 1,
+  [BackgroundVariant.TwinLines]: 1,
   [BackgroundVariant.Cross]: 6,
 };
 
 const selector = (s: ReactFlowState) => ({ transform: s.transform, patternId: `pattern-${s.rfId}` });
 
-function Background({
+function Background(props: BackgroundProps) {
+  if (props.variant !== BackgroundVariant.TwinLines) return <BackgroundImpl {...props}/>;
+  return (
+    <>
+      <BackgroundImpl {...props} key={"twin-1"} variant={BackgroundVariant.Lines}/>
+      <BackgroundImpl {...props} key={"twin-2"} gap={props.twinGap ?? 100}
+                      lineWidth={props.twinLineWidth ?? 1}
+                      color={props.twinColor ?? defaultColor[BackgroundVariant.TwinLines]}
+      />
+    </>
+  );
+}
+
+function BackgroundImpl({
   variant = BackgroundVariant.Dots,
   gap = 20,
   // only used for dots and cross
@@ -62,7 +77,7 @@ function Background({
       data-testid="rf__background"
     >
       <pattern
-        id={patternId}
+        id={patternId+variant}
         x={transform[0] % scaledGap[0]}
         y={transform[1] % scaledGap[1]}
         width={scaledGap[0]}
@@ -76,7 +91,7 @@ function Background({
           <LinePattern dimensions={patternDimensions} color={patternColor} lineWidth={lineWidth} />
         )}
       </pattern>
-      <rect x="0" y="0" width="100%" height="100%" fill={`url(#${patternId})`} />
+      <rect x="0" y="0" width="100%" height="100%" fill={`url(#${patternId+variant})`} />
     </svg>
   );
 }

--- a/packages/background/src/types.ts
+++ b/packages/background/src/types.ts
@@ -4,14 +4,18 @@ export enum BackgroundVariant {
   Lines = 'lines',
   Dots = 'dots',
   Cross = 'cross',
+  TwinLines = 'twinLines'
 }
 
 export type BackgroundProps = {
   color?: string;
+  twinColor?: string;
   className?: string;
   gap?: number | [number, number];
+  twinGap?: number | [number, number];
   size?: number;
   lineWidth?: number;
+  twinLineWidth?: number;
   variant?: BackgroundVariant;
   style?: CSSProperties;
 };


### PR DESCRIPTION
This adds new background variant type `TwinLines` (4th on the screenshot below).

![scrn](https://user-images.githubusercontent.com/2056864/226434692-565aeb5d-cfbb-49a4-8c39-05b52d39de7f.png)

First line is controlled by the same properties as used in `Lines` variant; second line width, gap and color are controlled with `twinLineWidth`, `twinGap` and `twinColor` properties.

Related discussion: https://github.com/wbkd/react-flow/discussions/2937