### PR TITLE
fix(key-press): mac issue keyup not triggered

### DIFF
--- a/packages/core/src/hooks/useKeyPress.ts
+++ b/packages/core/src/hooks/useKeyPress.ts
@@ -75,8 +75,8 @@ export default (keyCode: KeyCode | null = null, options: UseKeyPressOptions = { 
         }
 
         // fix for Mac: when cmd key is pressed, keyup is not triggered for any other key, see: https://stackoverflow.com/questions/27380018/when-cmd-key-is-kept-pressed-keyup-is-not-triggered-for-any-other-key
-        if (event.key === "Meta") {
-          pressedKeys.current.clear()
+        if (event.key === 'Meta') {
+          pressedKeys.current.clear();
         }
 
         modifierPressed.current = false;

--- a/packages/core/src/hooks/useKeyPress.ts
+++ b/packages/core/src/hooks/useKeyPress.ts
@@ -14,7 +14,7 @@ const doc = typeof document !== 'undefined' ? document : null;
 
 // the keycode can be a string 'a' or an array of strings ['a', 'a+d']
 // a string means a single key 'a' or a combination when '+' is used 'a+d'
-// an array means different possibilites. Explainer: ['a', 'd+s'] here the
+// an array means different possibilities. Explainer: ['a', 'd+s'] here the
 // user can use the single key 'a' or the combination 'd' + 's'
 export default (keyCode: KeyCode | null = null, options: UseKeyPressOptions = { target: doc }): boolean => {
   const [keyPressed, setKeyPressed] = useState(false);
@@ -73,6 +73,12 @@ export default (keyCode: KeyCode | null = null, options: UseKeyPressOptions = { 
         } else {
           pressedKeys.current.delete(event[keyOrCode]);
         }
+
+        // fix for Mac: when cmd key is pressed, keyup is not triggered for any other key, see: https://stackoverflow.com/questions/27380018/when-cmd-key-is-kept-pressed-keyup-is-not-triggered-for-any-other-key
+        if (event.key === "Meta") {
+          pressedKeys.current.clear()
+        }
+
         modifierPressed.current = false;
       };
 


### PR DESCRIPTION
### Issue
When pressing incorrect keys (according to the given keys to watch), when letting go of all keys some keys will stay as they are still pressed, hence making the `isMatchingKey` faulty and not trigger.

### Reason
See https://stackoverflow.com/questions/27380018/when-cmd-key-is-kept-pressed-keyup-is-not-triggered-for-any-other-key

### Solution
When retrieving an up-event for Meta key, remove all pressed keys.