### PR TITLE
Add support for pointer events and the ability to opt-out of pointer capture

### DIFF
--- a/packages/core/src/components/Edges/utils.ts
+++ b/packages/core/src/components/Edges/utils.ts
@@ -1,4 +1,4 @@
-import { MouseEvent as ReactMouseEvent } from 'react';
+import { MouseEvent as ReactMouseEvent, PointerEvent as ReactPointerEvent } from 'react';
 import { StoreApi } from 'zustand';
 
 import type { Edge, MarkerType, ReactFlowState } from '../../types';
@@ -19,6 +19,22 @@ export function getMouseHandler(
   return handler === undefined
     ? handler
     : (event: ReactMouseEvent<SVGGElement, MouseEvent>) => {
+        const edge = getState().edges.find((e) => e.id === id);
+
+        if (edge) {
+          handler(event, { ...edge });
+        }
+      };
+}
+
+export function getPointerHandler(
+  id: string,
+  getState: StoreApi<ReactFlowState>['getState'],
+  handler?: (event: ReactPointerEvent<SVGGElement>, edge: Edge) => void
+) {
+  return handler === undefined
+    ? handler
+    : (event: ReactPointerEvent<SVGGElement>) => {
         const edge = getState().edges.find((e) => e.id === id);
 
         if (edge) {

--- a/packages/core/src/components/Edges/wrapEdge.tsx
+++ b/packages/core/src/components/Edges/wrapEdge.tsx
@@ -10,6 +10,7 @@ import { getMarkerId } from '../../utils/graph';
 import { getMouseHandler, getPointerHandler } from './utils';
 import { elementSelectionKeys } from '../../utils';
 import type { EdgeProps, WrapEdgeProps, Connection } from '../../types';
+import { onPointerDownDisableCapture } from '../../utils/pointerEvents';
 
 const alwaysValidConnection = () => true;
 
@@ -61,6 +62,7 @@ export default (EdgeComponent: ComponentType<EdgeProps>) => {
     isUpdatable,
     pathOptions,
     interactionWidth,
+    disablePointerCapture,
   }: WrapEdgeProps): JSX.Element | null => {
     const edgeRef = useRef<SVGGElement>(null);
     const [updateHover, setUpdateHover] = useState<boolean>(false);
@@ -176,6 +178,7 @@ export default (EdgeComponent: ComponentType<EdgeProps>) => {
         onMouseEnter={onEdgeMouseEnter}
         onMouseMove={onEdgeMouseMove}
         onMouseLeave={onEdgeMouseLeave}
+        onPointerDown={disablePointerCapture ? onPointerDownDisableCapture : undefined}
         onPointerEnter={onEdgePointerEnter}
         onPointerMove={onEdgePointerMove}
         onPointerLeave={onEdgePointerLeave}

--- a/packages/core/src/components/Edges/wrapEdge.tsx
+++ b/packages/core/src/components/Edges/wrapEdge.tsx
@@ -7,7 +7,7 @@ import { ARIA_EDGE_DESC_KEY } from '../A11yDescriptions';
 import { handlePointerDown } from '../Handle/handler';
 import { EdgeAnchor } from './EdgeAnchor';
 import { getMarkerId } from '../../utils/graph';
-import { getMouseHandler } from './utils';
+import { getMouseHandler, getPointerHandler } from './utils';
 import { elementSelectionKeys } from '../../utils';
 import type { EdgeProps, WrapEdgeProps, Connection } from '../../types';
 
@@ -46,6 +46,9 @@ export default (EdgeComponent: ComponentType<EdgeProps>) => {
     onMouseEnter,
     onMouseMove,
     onMouseLeave,
+    onPointerEnter,
+    onPointerMove,
+    onPointerLeave,
     edgeUpdaterRadius,
     onEdgeUpdate,
     onEdgeUpdateStart,
@@ -87,9 +90,14 @@ export default (EdgeComponent: ComponentType<EdgeProps>) => {
 
     const onEdgeDoubleClickHandler = getMouseHandler(id, store.getState, onEdgeDoubleClick);
     const onEdgeContextMenu = getMouseHandler(id, store.getState, onContextMenu);
+
     const onEdgeMouseEnter = getMouseHandler(id, store.getState, onMouseEnter);
     const onEdgeMouseMove = getMouseHandler(id, store.getState, onMouseMove);
     const onEdgeMouseLeave = getMouseHandler(id, store.getState, onMouseLeave);
+
+    const onEdgePointerEnter = getPointerHandler(id, store.getState, onPointerEnter);
+    const onEdgePointerMove = getPointerHandler(id, store.getState, onPointerMove);
+    const onEdgePointerLeave = getPointerHandler(id, store.getState, onPointerLeave);
 
     const handleEdgeUpdater = (event: React.MouseEvent<SVGGElement, MouseEvent>, isSourceHandle: boolean) => {
       // avoid triggering edge updater if mouse btn is not left
@@ -168,6 +176,9 @@ export default (EdgeComponent: ComponentType<EdgeProps>) => {
         onMouseEnter={onEdgeMouseEnter}
         onMouseMove={onEdgeMouseMove}
         onMouseLeave={onEdgeMouseLeave}
+        onPointerEnter={onEdgePointerEnter}
+        onPointerMove={onEdgePointerMove}
+        onPointerLeave={onEdgePointerLeave}
         onKeyDown={isFocusable ? onKeyDown : undefined}
         tabIndex={isFocusable ? 0 : undefined}
         role={isFocusable ? 'button' : undefined}

--- a/packages/core/src/components/Nodes/utils.ts
+++ b/packages/core/src/components/Nodes/utils.ts
@@ -1,4 +1,4 @@
-import { MouseEvent, RefObject } from 'react';
+import { MouseEvent, PointerEvent, RefObject } from 'react';
 import { StoreApi } from 'zustand';
 
 import { getDimensions } from '../../utils';
@@ -45,6 +45,19 @@ export function getMouseHandler(
   return handler === undefined
     ? handler
     : (event: MouseEvent) => {
+        const node = getState().nodeInternals.get(id)!;
+        handler(event, { ...node });
+      };
+}
+
+export function getPointerHandler(
+  id: string,
+  getState: StoreApi<ReactFlowState>['getState'],
+  handler?: (event: PointerEvent, node: Node) => void
+) {
+  return handler === undefined
+    ? handler
+    : (event: PointerEvent) => {
         const node = getState().nodeInternals.get(id)!;
         handler(event, { ...node });
       };

--- a/packages/core/src/components/Nodes/wrapNode.tsx
+++ b/packages/core/src/components/Nodes/wrapNode.tsx
@@ -10,6 +10,7 @@ import useUpdateNodePositions from '../../hooks/useUpdateNodePositions';
 import { getMouseHandler, getPointerHandler, handleNodeClick } from './utils';
 import { elementSelectionKeys, isInputDOMNode } from '../../utils';
 import type { NodeProps, WrapNodeProps, XYPosition } from '../../types';
+import { onPointerDownDisableCapture } from '../../utils/pointerEvents';
 
 export const arrowKeyDiffs: Record<string, XYPosition> = {
   ArrowUp: { x: 0, y: -1 },
@@ -55,6 +56,7 @@ export default (NodeComponent: ComponentType<NodeProps>) => {
     noPanClassName,
     initialized,
     disableKeyboardA11y,
+    disablePointerCapture,
     ariaLabel,
     rfId,
   }: WrapNodeProps) => {
@@ -199,6 +201,7 @@ export default (NodeComponent: ComponentType<NodeProps>) => {
         onMouseEnter={onMouseEnterHandler}
         onMouseMove={onMouseMoveHandler}
         onMouseLeave={onMouseLeaveHandler}
+        onPointerDown={disablePointerCapture ? onPointerDownDisableCapture : undefined}
         onPointerEnter={onPointerEnterHandler}
         onPointerMove={onPointerMoveHandler}
         onPointerLeave={onPointerLeaveHandler}

--- a/packages/core/src/components/Nodes/wrapNode.tsx
+++ b/packages/core/src/components/Nodes/wrapNode.tsx
@@ -7,7 +7,7 @@ import { Provider } from '../../contexts/NodeIdContext';
 import { ARIA_NODE_DESC_KEY } from '../A11yDescriptions';
 import useDrag from '../../hooks/useDrag';
 import useUpdateNodePositions from '../../hooks/useUpdateNodePositions';
-import { getMouseHandler, handleNodeClick } from './utils';
+import { getMouseHandler, getPointerHandler, handleNodeClick } from './utils';
 import { elementSelectionKeys, isInputDOMNode } from '../../utils';
 import type { NodeProps, WrapNodeProps, XYPosition } from '../../types';
 
@@ -32,6 +32,9 @@ export default (NodeComponent: ComponentType<NodeProps>) => {
     onMouseEnter,
     onMouseMove,
     onMouseLeave,
+    onPointerEnter,
+    onPointerMove,
+    onPointerLeave,
     onContextMenu,
     onDoubleClick,
     style,
@@ -66,6 +69,11 @@ export default (NodeComponent: ComponentType<NodeProps>) => {
     const onMouseEnterHandler = getMouseHandler(id, store.getState, onMouseEnter);
     const onMouseMoveHandler = getMouseHandler(id, store.getState, onMouseMove);
     const onMouseLeaveHandler = getMouseHandler(id, store.getState, onMouseLeave);
+
+    const onPointerEnterHandler = getPointerHandler(id, store.getState, onPointerEnter);
+    const onPointerMoveHandler = getPointerHandler(id, store.getState, onPointerMove);
+    const onPointerLeaveHandler = getPointerHandler(id, store.getState, onPointerLeave);
+
     const onContextMenuHandler = getMouseHandler(id, store.getState, onContextMenu);
     const onDoubleClickHandler = getMouseHandler(id, store.getState, onDoubleClick);
     const onSelectNodeHandler = (event: MouseEvent) => {
@@ -191,6 +199,9 @@ export default (NodeComponent: ComponentType<NodeProps>) => {
         onMouseEnter={onMouseEnterHandler}
         onMouseMove={onMouseMoveHandler}
         onMouseLeave={onMouseLeaveHandler}
+        onPointerEnter={onPointerEnterHandler}
+        onPointerMove={onPointerMoveHandler}
+        onPointerLeave={onPointerLeaveHandler}
         onContextMenu={onContextMenuHandler}
         onClick={onSelectNodeHandler}
         onDoubleClick={onDoubleClickHandler}

--- a/packages/core/src/container/EdgeRenderer/index.tsx
+++ b/packages/core/src/container/EdgeRenderer/index.tsx
@@ -24,6 +24,9 @@ type EdgeRendererProps = Pick<
   | 'onEdgeMouseEnter'
   | 'onEdgeMouseMove'
   | 'onEdgeMouseLeave'
+  | 'onEdgePointerEnter'
+  | 'onEdgePointerMove'
+  | 'onEdgePointerLeave'
   | 'onEdgeUpdateStart'
   | 'onEdgeUpdateEnd'
   | 'edgeUpdaterRadius'
@@ -60,6 +63,9 @@ const EdgeRenderer = ({
   onEdgeMouseEnter,
   onEdgeMouseMove,
   onEdgeMouseLeave,
+  onEdgePointerEnter,
+  onEdgePointerMove,
+  onEdgePointerLeave,
   onEdgeClick,
   edgeUpdaterRadius,
   onEdgeDoubleClick,
@@ -167,6 +173,9 @@ const EdgeRenderer = ({
                   onMouseEnter={onEdgeMouseEnter}
                   onMouseMove={onEdgeMouseMove}
                   onMouseLeave={onEdgeMouseLeave}
+                  onPointerEnter={onEdgePointerEnter}
+                  onPointerMove={onEdgePointerMove}
+                  onPointerLeave={onEdgePointerLeave}
                   onClick={onEdgeClick}
                   edgeUpdaterRadius={edgeUpdaterRadius}
                   onEdgeDoubleClick={onEdgeDoubleClick}

--- a/packages/core/src/container/EdgeRenderer/index.tsx
+++ b/packages/core/src/container/EdgeRenderer/index.tsx
@@ -34,6 +34,7 @@ type EdgeRendererProps = Pick<
   | 'elevateEdgesOnSelect'
   | 'rfId'
   | 'disableKeyboardA11y'
+  | 'disablePointerCapture'
 > & {
   elevateEdgesOnSelect: boolean;
   children: ReactNode;
@@ -72,6 +73,7 @@ const EdgeRenderer = ({
   onEdgeUpdateStart,
   onEdgeUpdateEnd,
   children,
+  disablePointerCapture,
 }: EdgeRendererProps) => {
   const { edgesFocusable, edgesUpdatable, elementsSelectable, width, height, connectionMode, nodeInternals, onError } =
     useStore(selector, shallow);
@@ -187,6 +189,7 @@ const EdgeRenderer = ({
                   isUpdatable={isUpdatable}
                   pathOptions={'pathOptions' in edge ? edge.pathOptions : undefined}
                   interactionWidth={edge.interactionWidth}
+                  disablePointerCapture={disablePointerCapture}
                 />
               );
             })}

--- a/packages/core/src/container/GraphView/index.tsx
+++ b/packages/core/src/container/GraphView/index.tsx
@@ -50,6 +50,9 @@ const GraphView = ({
   onNodeMouseEnter,
   onNodeMouseMove,
   onNodeMouseLeave,
+  onNodePointerEnter,
+  onNodePointerMove,
+  onNodePointerLeave,
   onNodeContextMenu,
   onSelectionContextMenu,
   onSelectionStart,
@@ -92,6 +95,9 @@ const GraphView = ({
   onEdgeMouseEnter,
   onEdgeMouseMove,
   onEdgeMouseLeave,
+  onEdgePointerEnter,
+  onEdgePointerMove,
+  onEdgePointerLeave,
   edgeUpdaterRadius,
   onEdgeUpdateStart,
   onEdgeUpdateEnd,
@@ -156,6 +162,9 @@ const GraphView = ({
           onEdgeMouseEnter={onEdgeMouseEnter}
           onEdgeMouseMove={onEdgeMouseMove}
           onEdgeMouseLeave={onEdgeMouseLeave}
+          onEdgePointerEnter={onEdgePointerEnter}
+          onEdgePointerMove={onEdgePointerMove}
+          onEdgePointerLeave={onEdgePointerLeave}
           onEdgeUpdateStart={onEdgeUpdateStart}
           onEdgeUpdateEnd={onEdgeUpdateEnd}
           edgeUpdaterRadius={edgeUpdaterRadius}
@@ -181,6 +190,9 @@ const GraphView = ({
           onNodeMouseEnter={onNodeMouseEnter}
           onNodeMouseMove={onNodeMouseMove}
           onNodeMouseLeave={onNodeMouseLeave}
+          onNodePointerEnter={onNodePointerEnter}
+          onNodePointerMove={onNodePointerMove}
+          onNodePointerLeave={onNodePointerLeave}
           onNodeContextMenu={onNodeContextMenu}
           selectNodesOnDrag={selectNodesOnDrag}
           onlyRenderVisibleElements={onlyRenderVisibleElements}

--- a/packages/core/src/container/GraphView/index.tsx
+++ b/packages/core/src/container/GraphView/index.tsx
@@ -106,6 +106,7 @@ const GraphView = ({
   noPanClassName,
   elevateEdgesOnSelect,
   disableKeyboardA11y,
+  disablePointerCapture,
   nodeOrigin,
   nodeExtent,
   rfId,
@@ -172,6 +173,7 @@ const GraphView = ({
           noPanClassName={noPanClassName}
           elevateEdgesOnSelect={!!elevateEdgesOnSelect}
           disableKeyboardA11y={disableKeyboardA11y}
+          disablePointerCapture={disablePointerCapture}
           rfId={rfId}
         >
           <ConnectionLine
@@ -199,6 +201,7 @@ const GraphView = ({
           noPanClassName={noPanClassName}
           noDragClassName={noDragClassName}
           disableKeyboardA11y={disableKeyboardA11y}
+          disablePointerCapture={disablePointerCapture}
           nodeOrigin={nodeOrigin}
           nodeExtent={nodeExtent}
           rfId={rfId}

--- a/packages/core/src/container/NodeRenderer/index.tsx
+++ b/packages/core/src/container/NodeRenderer/index.tsx
@@ -30,6 +30,7 @@ type NodeRendererProps = Pick<
   | 'noDragClassName'
   | 'rfId'
   | 'disableKeyboardA11y'
+  | 'disablePointerCapture'
   | 'nodeOrigin'
   | 'nodeExtent'
 >;
@@ -145,6 +146,7 @@ const NodeRenderer = (props: NodeRendererProps) => {
             initialized={!!node.width && !!node.height}
             rfId={props.rfId}
             disableKeyboardA11y={props.disableKeyboardA11y}
+            disablePointerCapture={props.disablePointerCapture}
             ariaLabel={node.ariaLabel}
           />
         );

--- a/packages/core/src/container/NodeRenderer/index.tsx
+++ b/packages/core/src/container/NodeRenderer/index.tsx
@@ -21,6 +21,9 @@ type NodeRendererProps = Pick<
   | 'onNodeMouseEnter'
   | 'onNodeMouseMove'
   | 'onNodeMouseLeave'
+  | 'onNodePointerEnter'
+  | 'onNodePointerMove'
+  | 'onNodePointerLeave'
   | 'onNodeContextMenu'
   | 'onlyRenderVisibleElements'
   | 'noPanClassName'
@@ -123,6 +126,9 @@ const NodeRenderer = (props: NodeRendererProps) => {
             onMouseEnter={props.onNodeMouseEnter}
             onMouseMove={props.onNodeMouseMove}
             onMouseLeave={props.onNodeMouseLeave}
+            onPointerEnter={props.onNodePointerEnter}
+            onPointerMove={props.onNodePointerMove}
+            onPointerLeave={props.onNodePointerLeave}
             onContextMenu={props.onNodeContextMenu}
             onDoubleClick={props.onNodeDoubleClick}
             selected={!!node.selected}

--- a/packages/core/src/container/ReactFlow/index.tsx
+++ b/packages/core/src/container/ReactFlow/index.tsx
@@ -80,6 +80,9 @@ const ReactFlow = forwardRef<ReactFlowRefType, ReactFlowProps>(
       onNodeMouseEnter,
       onNodeMouseMove,
       onNodeMouseLeave,
+      onNodePointerEnter,
+      onNodePointerMove,
+      onNodePointerLeave,
       onNodeContextMenu,
       onNodeDoubleClick,
       onNodeDragStart,
@@ -144,6 +147,9 @@ const ReactFlow = forwardRef<ReactFlowRefType, ReactFlowProps>(
       onEdgeMouseEnter,
       onEdgeMouseMove,
       onEdgeMouseLeave,
+      onEdgePointerEnter,
+      onEdgePointerMove,
+      onEdgePointerLeave,
       onEdgeUpdateStart,
       onEdgeUpdateEnd,
       edgeUpdaterRadius = 10,
@@ -196,6 +202,9 @@ const ReactFlow = forwardRef<ReactFlowRefType, ReactFlowProps>(
             onNodeMouseEnter={onNodeMouseEnter}
             onNodeMouseMove={onNodeMouseMove}
             onNodeMouseLeave={onNodeMouseLeave}
+            onNodePointerEnter={onNodePointerEnter}
+            onNodePointerMove={onNodePointerMove}
+            onNodePointerLeave={onNodePointerLeave}
             onNodeContextMenu={onNodeContextMenu}
             onNodeDoubleClick={onNodeDoubleClick}
             nodeTypes={nodeTypesWrapped}
@@ -240,6 +249,9 @@ const ReactFlow = forwardRef<ReactFlowRefType, ReactFlowProps>(
             onEdgeMouseEnter={onEdgeMouseEnter}
             onEdgeMouseMove={onEdgeMouseMove}
             onEdgeMouseLeave={onEdgeMouseLeave}
+            onEdgePointerEnter={onEdgePointerEnter}
+            onEdgePointerMove={onEdgePointerMove}
+            onEdgePointerLeave={onEdgePointerLeave}
             onEdgeUpdateStart={onEdgeUpdateStart}
             onEdgeUpdateEnd={onEdgeUpdateEnd}
             edgeUpdaterRadius={edgeUpdaterRadius}

--- a/packages/core/src/container/ReactFlow/index.tsx
+++ b/packages/core/src/container/ReactFlow/index.tsx
@@ -171,6 +171,7 @@ const ReactFlow = forwardRef<ReactFlowRefType, ReactFlowProps>(
       autoPanOnNodeDrag = true,
       connectionRadius = 20,
       isValidConnection,
+      disablePointerCapture = false,
       onError,
       style,
       id,
@@ -262,6 +263,7 @@ const ReactFlow = forwardRef<ReactFlowRefType, ReactFlowProps>(
             elevateEdgesOnSelect={elevateEdgesOnSelect}
             rfId={rfId}
             disableKeyboardA11y={disableKeyboardA11y}
+            disablePointerCapture={disablePointerCapture}
             nodeOrigin={nodeOrigin}
             nodeExtent={nodeExtent}
           />

--- a/packages/core/src/types/component-props.ts
+++ b/packages/core/src/types/component-props.ts
@@ -37,6 +37,8 @@ import type {
   HandleType,
   SelectionMode,
   OnError,
+  EdgePointerHandler,
+  NodePointerHandler,
 } from '.';
 import { ValidConnectionFunc } from '../components/Handle/utils';
 
@@ -51,6 +53,9 @@ export type ReactFlowProps = HTMLAttributes<HTMLDivElement> & {
   onNodeMouseEnter?: NodeMouseHandler;
   onNodeMouseMove?: NodeMouseHandler;
   onNodeMouseLeave?: NodeMouseHandler;
+  onNodePointerEnter?: NodePointerHandler;
+  onNodePointerMove?: NodePointerHandler;
+  onNodePointerLeave?: NodePointerHandler;
   onNodeContextMenu?: NodeMouseHandler;
   onNodeDragStart?: NodeDragHandler;
   onNodeDrag?: NodeDragHandler;
@@ -61,6 +66,9 @@ export type ReactFlowProps = HTMLAttributes<HTMLDivElement> & {
   onEdgeMouseEnter?: EdgeMouseHandler;
   onEdgeMouseMove?: EdgeMouseHandler;
   onEdgeMouseLeave?: EdgeMouseHandler;
+  onEdgePointerEnter?: EdgePointerHandler;
+  onEdgePointerMove?: EdgePointerHandler;
+  onEdgePointerLeave?: EdgePointerHandler;
   onEdgeDoubleClick?: EdgeMouseHandler;
   onEdgeUpdateStart?: (event: ReactMouseEvent, edge: Edge, handleType: HandleType) => void;
   onEdgeUpdateEnd?: (event: MouseEvent | TouchEvent, edge: Edge, handleType: HandleType) => void;

--- a/packages/core/src/types/component-props.ts
+++ b/packages/core/src/types/component-props.ts
@@ -150,6 +150,7 @@ export type ReactFlowProps = HTMLAttributes<HTMLDivElement> & {
   elevateNodesOnSelect?: boolean;
   elevateEdgesOnSelect?: boolean;
   disableKeyboardA11y?: boolean;
+  disablePointerCapture?: boolean;
   autoPanOnNodeDrag?: boolean;
   autoPanOnConnect?: boolean;
   connectionRadius?: number;

--- a/packages/core/src/types/edges.ts
+++ b/packages/core/src/types/edges.ts
@@ -1,5 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import type { CSSProperties, ComponentType, HTMLAttributes, ReactNode, MouseEvent as ReactMouseEvent } from 'react';
+import type {
+  CSSProperties,
+  ComponentType,
+  HTMLAttributes,
+  ReactNode,
+  MouseEvent as ReactMouseEvent,
+  PointerEvent as ReactPointerEvent,
+} from 'react';
 
 import { ConnectionStatus, Position } from '.';
 import type { Connection, HandleElement, HandleType, Node } from '.';
@@ -68,6 +75,7 @@ export type DefaultEdgeOptions = Omit<
 >;
 
 export type EdgeMouseHandler = (event: ReactMouseEvent, edge: Edge) => void;
+export type EdgePointerHandler = (event: ReactPointerEvent, edge: Edge) => void;
 
 export type WrapEdgeProps<T = any> = Omit<Edge<T>, 'sourceHandle' | 'targetHandle'> & {
   onClick?: EdgeMouseHandler;
@@ -86,6 +94,9 @@ export type WrapEdgeProps<T = any> = Omit<Edge<T>, 'sourceHandle' | 'targetHandl
   onMouseEnter?: EdgeMouseHandler;
   onMouseMove?: EdgeMouseHandler;
   onMouseLeave?: EdgeMouseHandler;
+  onPointerEnter?: EdgePointerHandler;
+  onPointerMove?: EdgePointerHandler;
+  onPointerLeave?: EdgePointerHandler;
   edgeUpdaterRadius?: number;
   onEdgeUpdateStart?: (event: ReactMouseEvent, edge: Edge, handleType: HandleType) => void;
   onEdgeUpdateEnd?: (event: MouseEvent | TouchEvent, edge: Edge, handleType: HandleType) => void;

--- a/packages/core/src/types/edges.ts
+++ b/packages/core/src/types/edges.ts
@@ -104,6 +104,7 @@ export type WrapEdgeProps<T = any> = Omit<Edge<T>, 'sourceHandle' | 'targetHandl
   isFocusable: boolean;
   isUpdatable: EdgeUpdatable;
   pathOptions?: BezierPathOptions | SmoothStepPathOptions;
+  disablePointerCapture?: boolean;
 };
 
 // props that get passed to a custom edge

--- a/packages/core/src/types/nodes.ts
+++ b/packages/core/src/types/nodes.ts
@@ -76,6 +76,7 @@ export type WrapNodeProps<T = any> = Pick<
     noPanClassName: string;
     rfId: string;
     disableKeyboardA11y: boolean;
+    disablePointerCapture?: boolean;
   };
 
 // props that get passed to a custom node

--- a/packages/core/src/types/nodes.ts
+++ b/packages/core/src/types/nodes.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import type { CSSProperties, MouseEvent as ReactMouseEvent } from 'react';
+import type { CSSProperties, MouseEvent as ReactMouseEvent, PointerEvent as ReactPointerEvent } from 'react';
 
 import { internalsSymbol } from '../utils';
 import type { XYPosition, Position, CoordinateExtent, HandleElement } from '.';
@@ -42,6 +42,7 @@ export type Node<T = any, U extends string | undefined = string | undefined> = {
 };
 
 export type NodeMouseHandler = (event: ReactMouseEvent, node: Node) => void;
+export type NodePointerHandler = (event: ReactPointerEvent, node: Node) => void;
 export type NodeDragHandler = (event: ReactMouseEvent, node: Node, nodes: Node[]) => void;
 export type SelectionDragHandler = (event: ReactMouseEvent, nodes: Node[]) => void;
 
@@ -65,6 +66,9 @@ export type WrapNodeProps<T = any> = Pick<
     onMouseEnter?: NodeMouseHandler;
     onMouseMove?: NodeMouseHandler;
     onMouseLeave?: NodeMouseHandler;
+    onPointerEnter?: NodePointerHandler;
+    onPointerMove?: NodePointerHandler;
+    onPointerLeave?: NodePointerHandler;
     onContextMenu?: NodeMouseHandler;
     resizeObserver: ResizeObserver | null;
     isParent: boolean;

--- a/packages/core/src/utils/pointerEvents.ts
+++ b/packages/core/src/utils/pointerEvents.ts
@@ -1,0 +1,15 @@
+import { PointerEvent } from 'react';
+
+type PointerTarget =
+  | Pick<HTMLElement, 'hasPointerCapture' | 'releasePointerCapture'>
+  | Pick<SVGElement, 'hasPointerCapture' | 'releasePointerCapture'>;
+
+export const onPointerDownDisableCapture = (event: PointerEvent<PointerTarget>) => {
+  const pointerTarget = event.target as unknown as PointerTarget;
+
+  if ('hasPointerCapture' in pointerTarget && 'releasePointerCapture' in pointerTarget) {
+    if (pointerTarget.hasPointerCapture(event.pointerId)) {
+      pointerTarget.releasePointerCapture(event.pointerId);
+    }
+  }
+};


### PR DESCRIPTION
### Issue

When using a `reactflow` in a mobile browser, touch enter/move/leave events are not handled.

### Solution

- Provide support for the more general _pointer_ enter/move/leave events.
- Provide the ability to opt-out of implicit pointer capturing

### Resources

- [What is implicit pointer capturing?](https://stackoverflow.com/a/70737325/225237)