### PR TITLE
Allow controlling offset scale of minimap

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ A highly customizable React component for building interactive graphs and node-b
 
 ---
 
+## 🚨 Upcoming Changes 
+
+The main branch (v11) is now in a feature freeze. The next version is being developed in the [xyflow branch](https://github.com/wbkd/react-flow/tree/xyflow).
+Find out more about the those changes [here](https://wbkd.notion.site/Upcoming-Changes-at-React-Flow-1a443641891a4069927c0a115e915251).
+
 ## Key Features
 
 - **Easy to use:** Seamless zooming and panning, single- and multi selection of graph elements and keyboard shortcuts are supported out of the box

--- a/packages/minimap/src/MiniMap.tsx
+++ b/packages/minimap/src/MiniMap.tsx
@@ -55,6 +55,7 @@ function MiniMap({
   ariaLabel = 'React Flow mini map',
   inversePan = false,
   zoomStep = 10,
+  offsetScale = 5
 }: MiniMapProps) {
   const store = useStoreApi();
   const svg = useRef<SVGSVGElement>(null);
@@ -67,7 +68,7 @@ function MiniMap({
   const viewScale = Math.max(scaledWidth, scaledHeight);
   const viewWidth = viewScale * elementWidth;
   const viewHeight = viewScale * elementHeight;
-  const offset = 5 * viewScale;
+  const offset = offsetScale * viewScale;
   const x = boundingRect.x - (viewWidth - boundingRect.width) / 2 - offset;
   const y = boundingRect.y - (viewHeight - boundingRect.height) / 2 - offset;
   const width = viewWidth + offset * 2;

--- a/packages/minimap/src/types.ts
+++ b/packages/minimap/src/types.ts
@@ -22,6 +22,7 @@ export type MiniMapProps<NodeData = any> = Omit<HTMLAttributes<SVGSVGElement>, '
   ariaLabel?: string | null;
   inversePan?: boolean;
   zoomStep?: number;
+  offsetScale?: number;
 };
 
 export type MiniMapNodes = Pick<

--- a/packages/reactflow/README.md
+++ b/packages/reactflow/README.md
@@ -15,6 +15,12 @@ A highly customizable React component for building interactive graphs and node-b
 
 ---
 
+## 🚨 Upcoming Changes 
+
+The main branch (v11) is now in a feature freeze. The next version is being developed in the [xyflow branch](https://github.com/wbkd/react-flow/tree/xyflow).
+Find out more about the those changes [here](https://wbkd.notion.site/Upcoming-Changes-at-React-Flow-1a443641891a4069927c0a115e915251).
+
+
 ## Key Features
 
 - **Easy to use:** Seamless zooming and panning, single- and multi selection of graph elements and keyboard shortcuts are supported out of the box
@@ -31,11 +37,6 @@ A highly customizable React component for building interactive graphs and node-b
 **Are you using React Flow at your organization and making money from it?** Awesome! We rely on your support to keep React Flow developed and maintained under an MIT License, just how we like it. You can do that on the [React Flow Pro website](https://pro.reactflow.dev) or through [Github Sponsors](https://github.com/sponsors/wbkd).
 
 You can find more information in our [React Flow Pro FAQs](https://pro.reactflow.dev/info).
-
-## What's New
-The main branch / v11 is now in a feature freeze. The next version is being developed in the /xyflow branch.
-You can find an unstable pre-alpha version of Svelte Flow in the /xyflow branch.
-Find out more about these changes [here](https://wbkd.notion.site/Upcoming-Changes-at-React-Flow-1a443641891a4069927c0a115e915251).
 
 
 ## Installation


### PR DESCRIPTION
Sorry for not creating a discussion first, but this one is pretty trivial.

Due to the `5` hard-coded value here:

https://github.com/wbkd/react-flow/blob/993a778b80cc1e80a47983ed75407b579313a73c/packages/minimap/src/MiniMap.tsx#L70

— minimap mask has a ~5px border even when the viewport is perfectly aligned with the map and all the nodes are inside: 

![img](https://github.com/wbkd/react-flow/assets/2056864/2a3f1d6b-e221-4a18-9d33-3eec04cf109f)

This doesn't work for me, as I need the mask to show only when nodes are outside the view or the view aspect ratio differs from map's, eg:

https://github.com/wbkd/react-flow/assets/2056864/bd93c88d-98aa-4b1c-aa16-6ccb88cd7379

Setting the value to 1 resolved the issue (and doesn't seem to break anything), but I guess it was added for a reason, hence the added prop with the old default value.

