### PR TITLE
Add minimap node selected prop and style

### DIFF
--- a/packages/minimap/src/MiniMapNode.tsx
+++ b/packages/minimap/src/MiniMapNode.tsx
@@ -16,13 +16,14 @@ const MiniMapNode = ({
   borderRadius,
   shapeRendering,
   onClick,
+  selected
 }: MiniMapNodeProps) => {
   const { background, backgroundColor } = style || {};
   const fill = (color || background || backgroundColor) as string;
 
   return (
     <rect
-      className={cc(['react-flow__minimap-node', className])}
+      className={cc(['react-flow__minimap-node', selected && 'selected', className])}
       x={x}
       y={y}
       rx={borderRadius}

--- a/packages/minimap/src/MiniMapNodes.tsx
+++ b/packages/minimap/src/MiniMapNodes.tsx
@@ -45,6 +45,7 @@ function MiniMapNodes({
             width={node.width!}
             height={node.height!}
             style={node.style}
+            selected={node.selected}
             className={nodeClassNameFunc(node)}
             color={nodeColorFunc(node)}
             borderRadius={nodeBorderRadius}

--- a/packages/minimap/src/style.css
+++ b/packages/minimap/src/style.css
@@ -1,3 +1,7 @@
 .react-flow__minimap {
   background-color: #fff;
 }
+
+.react-flow__minimap-node.selected {
+  filter: invert(30%);
+}

--- a/packages/minimap/src/types.ts
+++ b/packages/minimap/src/types.ts
@@ -43,6 +43,7 @@ export type MiniMapNodeProps = {
   shapeRendering: string;
   strokeColor: string;
   strokeWidth: number;
+  selected?: boolean;
   style?: CSSProperties;
   onClick?: (event: MouseEvent, id: string) => void;
 };


### PR DESCRIPTION
This adds `selected` css class to minimap node when it's selected and corresponding style to indicate selected nodes on minimap.

https://github.com/wbkd/react-flow/assets/2056864/14e72fda-2eb6-44b2-87d5-f53be3aa7023