### PR TITLE
Fix nodeTypes warning shown on shallow equals

### DIFF
--- a/packages/core/src/container/ReactFlow/utils.ts
+++ b/packages/core/src/container/ReactFlow/utils.ts
@@ -16,7 +16,7 @@ export function useNodeOrEdgeTypes(nodeOrEdgeTypes: any, createTypes: any): any 
   const typesParsed = useMemo(() => {
     if (process.env.NODE_ENV === 'development') {
       const typeKeys = Object.keys(nodeOrEdgeTypes);
-      if (shallow(typesKeysRef.current, typeKeys)) {
+      if (!shallow(typesKeysRef.current, typeKeys)) {
         devWarn('002', errorMessages['error002']());
       }
 


### PR DESCRIPTION
Currently a warning about memoizing the the nodeTypes object  is shown when the types are shallowly equal. Instead it should be shown when the consequent nodeTypes are **not** shallowly equal.