### PR TITLE
🐛  Fixes a bug where 'handleNodeClick' could runtime error if the node had already been removed.

### DIFF
--- a/.changeset/weak-geese-dream.md
+++ b/.changeset/weak-geese-dream.md
@@ -1,0 +1,5 @@
+---
+'@reactflow/core': patch
+---
+
+fix(handleNodeClick): handle deleted node

--- a/packages/core/src/components/Nodes/utils.ts
+++ b/packages/core/src/components/Nodes/utils.ts
@@ -46,8 +46,11 @@ export function getMouseHandler(
   return handler === undefined
     ? handler
     : (event: MouseEvent) => {
-        const node = getState().nodeInternals.get(id)!;
-        handler(event, { ...node });
+        const node = getState().nodeInternals.get(id);
+        
+        if (node) {
+          handler(event, { ...node });
+        }
       };
 }
 

--- a/packages/core/src/components/Nodes/utils.ts
+++ b/packages/core/src/components/Nodes/utils.ts
@@ -4,6 +4,7 @@ import { StoreApi } from 'zustand';
 import { getDimensions } from '../../utils';
 import { Position } from '../../types';
 import type { HandleElement, Node, NodeOrigin, ReactFlowState } from '../../types';
+import { errorMessages } from '../../contants';
 
 export const getHandleBounds = (
   selector: string,
@@ -68,8 +69,13 @@ export function handleNodeClick({
   unselect?: boolean;
   nodeRef?: RefObject<HTMLDivElement>;
 }) {
-  const { addSelectedNodes, unselectNodesAndEdges, multiSelectionActive, nodeInternals } = store.getState();
-  const node = nodeInternals.get(id)!;
+  const { addSelectedNodes, unselectNodesAndEdges, multiSelectionActive, nodeInternals, onError } = store.getState();
+  const node = nodeInternals.get(id);
+
+  if (!node) {
+    onError?.('012', errorMessages['error012'](id));
+    return;
+  }
 
   store.setState({ nodesSelectionActive: false });
 

--- a/packages/core/src/components/Nodes/wrapNode.tsx
+++ b/packages/core/src/components/Nodes/wrapNode.tsx
@@ -79,8 +79,11 @@ export default (NodeComponent: ComponentType<NodeProps>) => {
       }
 
       if (onClick) {
-        const node = store.getState().nodeInternals.get(id)!;
-        onClick(event, { ...node });
+        const node = store.getState().nodeInternals.get(id);
+
+        if (node) {
+          onClick(event, { ...node });
+        }
       }
     };
 

--- a/packages/core/src/contants.ts
+++ b/packages/core/src/contants.ts
@@ -18,5 +18,5 @@ export const errorMessages = {
   error010: () => 'Handle: No node id found. Make sure to only use a Handle inside a custom Node.',
   error011: (edgeType: string) => `Edge type "${edgeType}" not found. Using fallback type "default".`,
   error012: (id: string) =>
-    `Node with id "${id}" does not exist, it may have been removed. This can happen when a node is deleted before the "onNodeClick" handler is called. If this wasn't on purpose, please defer deleting this node until the "onNodeClick" handler is called by using "requestAnimationFrame" or "setTimeout".`,
+    `Node with id "${id}" does not exist, it may have been removed. This can happen when a node is deleted before the "onNodeClick" handler is called.`,
 };

--- a/packages/core/src/contants.ts
+++ b/packages/core/src/contants.ts
@@ -17,4 +17,6 @@ export const errorMessages = {
     }", edge id: ${edge.id}.`,
   error010: () => 'Handle: No node id found. Make sure to only use a Handle inside a custom Node.',
   error011: (edgeType: string) => `Edge type "${edgeType}" not found. Using fallback type "default".`,
+  error012: (id: string) =>
+    `Node with id "${id}" does not exist, it may have been removed. This can happen when a node is deleted before the "onNodeClick" handler is called. If this wasn't on purpose, please defer deleting this node until the "onNodeClick" handler is called by using "requestAnimationFrame" or "setTimeout".`,
 };


### PR DESCRIPTION
Two changes:

- `handleNodeClick` no-ops if the target node doesn't exist.
- A new error is reported:

```js
`Node with id "${id}" does not exist, it may have been removed. This can happen when a node is deleted before the "onNodeClick" handler is called. If this wasn't on purpose, please defer deleting this node until the "onNodeClick" handler is called by using "requestAnimationFrame" or "setTimeout".`
```

This can come up if a custom node has a delete button, for example, and the user _also_ has a `onNodeClick` handler set up on the `<ReactFlow>` component.