### PR TITLE
removed rogue console log

### DIFF
--- a/packages/svelte/src/lib/actions/drag/index.ts
+++ b/packages/svelte/src/lib/actions/drag/index.ts
@@ -36,9 +36,6 @@ export default function drag(domNode: Element, params: UseDragParams) {
         updateNodePositions: store.updateNodePositions,
         panBy: store.panBy
       };
-    },
-    onNodeClick: () => {
-      console.log('node click');
     }
   });
 


### PR DESCRIPTION
Noticed that I was getting a random log when clicking/dragging nodes with a fresh npm install of @xyflow/svelte. Removing to avoid confusion.