### PR TITLE
fix(packages): support newer setups (astro, remix, ..) and older setups (webpack 4, react 17)

### DIFF
--- a/.changeset/curvy-rocks-impress.md
+++ b/.changeset/curvy-rocks-impress.md
@@ -1,0 +1,11 @@
+---
+'@reactflow/background': minor
+'@reactflow/controls': minor
+'@reactflow/core': minor
+'@reactflow/minimap': minor
+'@reactflow/node-resizer': minor
+'@reactflow/node-toolbar': minor
+'reactflow': minor
+---
+
+fix(packages): support newer setups (astro, remix, ..) and older setups (webpack 4, react 17)

--- a/packages/background/package.json
+++ b/packages/background/package.json
@@ -20,7 +20,7 @@
   "exports": {
     ".": {
       "types": "./dist/esm/index.d.ts",
-      "import": "./dist/esm/index.js",
+      "import": "./dist/esm/index.mjs",
       "require": "./dist/umd/index.js"
     }
   },

--- a/packages/background/src/Background.tsx
+++ b/packages/background/src/Background.tsx
@@ -1,4 +1,4 @@
-import { memo, useRef } from 'react';
+import React, { memo, useRef } from 'react';
 import cc from 'classcat';
 import { useStore, ReactFlowState } from '@reactflow/core';
 import { shallow } from 'zustand/shallow';
@@ -64,7 +64,7 @@ function Background({
       data-testid="rf__background"
     >
       <pattern
-        id={patternId+id}
+        id={patternId + id}
         x={transform[0] % scaledGap[0]}
         y={transform[1] % scaledGap[1]}
         width={scaledGap[0]}
@@ -78,7 +78,7 @@ function Background({
           <LinePattern dimensions={patternDimensions} color={patternColor} lineWidth={lineWidth} />
         )}
       </pattern>
-      <rect x="0" y="0" width="100%" height="100%" fill={`url(#${patternId+id})`} />
+      <rect x="0" y="0" width="100%" height="100%" fill={`url(#${patternId + id})`} />
     </svg>
   );
 }

--- a/packages/background/src/Patterns.tsx
+++ b/packages/background/src/Patterns.tsx
@@ -1,21 +1,17 @@
+import React from 'react';
+
 type LinePatternProps = {
   dimensions: [number, number];
   lineWidth?: number;
   color: string;
 };
 
-export function LinePattern({
-  color,
-  dimensions,
-  lineWidth,
-}: LinePatternProps) {
+export function LinePattern({ color, dimensions, lineWidth }: LinePatternProps) {
   return (
     <path
       stroke={color}
       strokeWidth={lineWidth}
-      d={`M${dimensions[0] / 2} 0 V${dimensions[1]} M0 ${dimensions[1] / 2} H${
-        dimensions[0]
-      }`}
+      d={`M${dimensions[0] / 2} 0 V${dimensions[1]} M0 ${dimensions[1] / 2} H${dimensions[0]}`}
     />
   );
 }

--- a/packages/controls/package.json
+++ b/packages/controls/package.json
@@ -20,7 +20,7 @@
   "exports": {
     ".": {
       "types": "./dist/esm/index.d.ts",
-      "import": "./dist/esm/index.js",
+      "import": "./dist/esm/index.mjs",
       "require": "./dist/umd/index.js"
     },
     "./dist/style.css": "./dist/style.css"

--- a/packages/controls/src/ControlButton.tsx
+++ b/packages/controls/src/ControlButton.tsx
@@ -1,4 +1,4 @@
-import type { FC, PropsWithChildren } from 'react';
+import React, { type FC, type PropsWithChildren } from 'react';
 import cc from 'classcat';
 
 import type { ControlButtonProps } from './types';

--- a/packages/controls/src/Controls.tsx
+++ b/packages/controls/src/Controls.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useState, type FC, type PropsWithChildren } from 'react';
+import React, { memo, useEffect, useState, type FC, type PropsWithChildren } from 'react';
 import cc from 'classcat';
 import { shallow } from 'zustand/shallow';
 import { useStore, useStoreApi, useReactFlow, Panel, type ReactFlowState } from '@reactflow/core';

--- a/packages/controls/src/Icons/FitView.tsx
+++ b/packages/controls/src/Icons/FitView.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 function FitViewIcon() {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 30">

--- a/packages/controls/src/Icons/Lock.tsx
+++ b/packages/controls/src/Icons/Lock.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 function LockIcon() {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 32">

--- a/packages/controls/src/Icons/Minus.tsx
+++ b/packages/controls/src/Icons/Minus.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 function MinusIcon() {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 5">

--- a/packages/controls/src/Icons/Plus.tsx
+++ b/packages/controls/src/Icons/Plus.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 function PlusIcon() {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">

--- a/packages/controls/src/Icons/Unlock.tsx
+++ b/packages/controls/src/Icons/Unlock.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 function UnlockIcon() {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 32">

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,7 @@
   "exports": {
     ".": {
       "types": "./dist/esm/index.d.ts",
-      "import": "./dist/esm/index.js",
+      "import": "./dist/esm/index.mjs",
       "require": "./dist/umd/index.js"
     },
     "./dist/base.css": "./dist/base.css",

--- a/packages/core/src/components/A11yDescriptions/index.tsx
+++ b/packages/core/src/components/A11yDescriptions/index.tsx
@@ -1,4 +1,5 @@
-import { CSSProperties } from 'react';
+import React, { type CSSProperties } from 'react';
+
 import { useStore } from '../../hooks/useStore';
 import type { ReactFlowState } from '../../types';
 

--- a/packages/core/src/components/Attribution/index.tsx
+++ b/packages/core/src/components/Attribution/index.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import Panel from '../Panel';
 import type { PanelPosition, ProOptions } from '../../types';
 

--- a/packages/core/src/components/ConnectionLine/index.tsx
+++ b/packages/core/src/components/ConnectionLine/index.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, useCallback } from 'react';
+import React, { type CSSProperties, useCallback } from 'react';
 import { shallow } from 'zustand/shallow';
 import cc from 'classcat';
 

--- a/packages/core/src/components/EdgeLabelRenderer/index.tsx
+++ b/packages/core/src/components/EdgeLabelRenderer/index.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import { type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 
 import { useStore } from '../../hooks/useStore';

--- a/packages/core/src/components/Edges/BaseEdge.tsx
+++ b/packages/core/src/components/Edges/BaseEdge.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import EdgeText from './EdgeText';
 import { isNumeric } from '../../utils';
 import type { BaseEdgeProps } from '../../types';

--- a/packages/core/src/components/Edges/BezierEdge.tsx
+++ b/packages/core/src/components/Edges/BezierEdge.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import React, { memo } from 'react';
 
 import BaseEdge from './BaseEdge';
 import { getBezierEdgeCenter } from './utils';

--- a/packages/core/src/components/Edges/EdgeAnchor.tsx
+++ b/packages/core/src/components/Edges/EdgeAnchor.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import type { FC, MouseEvent as ReactMouseEvent, SVGAttributes } from 'react';
 import cc from 'classcat';
 

--- a/packages/core/src/components/Edges/EdgeText.tsx
+++ b/packages/core/src/components/Edges/EdgeText.tsx
@@ -1,4 +1,4 @@
-import { memo, useRef, useState, useEffect } from 'react';
+import React, { memo, useRef, useState, useEffect } from 'react';
 import type { FC, PropsWithChildren } from 'react';
 import cc from 'classcat';
 

--- a/packages/core/src/components/Edges/SimpleBezierEdge.tsx
+++ b/packages/core/src/components/Edges/SimpleBezierEdge.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import React, { memo } from 'react';
 
 import BaseEdge from './BaseEdge';
 import { getBezierEdgeCenter } from './utils';

--- a/packages/core/src/components/Edges/SmoothStepEdge.tsx
+++ b/packages/core/src/components/Edges/SmoothStepEdge.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import React, { memo } from 'react';
 
 import BaseEdge from './BaseEdge';
 import { getEdgeCenter } from './utils';

--- a/packages/core/src/components/Edges/StepEdge.tsx
+++ b/packages/core/src/components/Edges/StepEdge.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo } from 'react';
+import React, { memo, useMemo } from 'react';
 
 import SmoothStepEdge from './SmoothStepEdge';
 import type { SmoothStepEdgeProps } from '../../types';

--- a/packages/core/src/components/Edges/StraightEdge.tsx
+++ b/packages/core/src/components/Edges/StraightEdge.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import React, { memo } from 'react';
 
 import BaseEdge from './BaseEdge';
 import { getEdgeCenter } from './utils';

--- a/packages/core/src/components/Edges/wrapEdge.tsx
+++ b/packages/core/src/components/Edges/wrapEdge.tsx
@@ -1,4 +1,4 @@
-import { memo, useState, useMemo, useRef } from 'react';
+import React, { memo, useState, useMemo, useRef } from 'react';
 import type { ComponentType, KeyboardEvent } from 'react';
 import cc from 'classcat';
 

--- a/packages/core/src/components/Handle/index.tsx
+++ b/packages/core/src/components/Handle/index.tsx
@@ -1,4 +1,10 @@
-import { memo, HTMLAttributes, forwardRef, MouseEvent as ReactMouseEvent, TouchEvent as ReactTouchEvent } from 'react';
+import React, {
+  memo,
+  HTMLAttributes,
+  forwardRef,
+  MouseEvent as ReactMouseEvent,
+  TouchEvent as ReactTouchEvent,
+} from 'react';
 import cc from 'classcat';
 import { shallow } from 'zustand/shallow';
 

--- a/packages/core/src/components/Nodes/DefaultNode.tsx
+++ b/packages/core/src/components/Nodes/DefaultNode.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import React, { memo } from 'react';
 
 import Handle from '../../components/Handle';
 import { Position } from '../../types';

--- a/packages/core/src/components/Nodes/InputNode.tsx
+++ b/packages/core/src/components/Nodes/InputNode.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import React, { memo } from 'react';
 
 import Handle from '../../components/Handle';
 import { Position } from '../../types';

--- a/packages/core/src/components/Nodes/OutputNode.tsx
+++ b/packages/core/src/components/Nodes/OutputNode.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import React, { memo } from 'react';
 
 import Handle from '../../components/Handle';
 import { Position } from '../../types';

--- a/packages/core/src/components/Nodes/wrapNode.tsx
+++ b/packages/core/src/components/Nodes/wrapNode.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, memo } from 'react';
+import React, { useEffect, useRef, memo } from 'react';
 import type { ComponentType, MouseEvent, KeyboardEvent } from 'react';
 import cc from 'classcat';
 

--- a/packages/core/src/components/NodesSelection/index.tsx
+++ b/packages/core/src/components/NodesSelection/index.tsx
@@ -3,7 +3,7 @@
  * made a selection with on or several nodes
  */
 
-import { memo, useRef, useEffect } from 'react';
+import React, { memo, useRef, useEffect } from 'react';
 import type { MouseEvent, KeyboardEvent } from 'react';
 import cc from 'classcat';
 import { shallow } from 'zustand/shallow';

--- a/packages/core/src/components/Panel/index.tsx
+++ b/packages/core/src/components/Panel/index.tsx
@@ -1,4 +1,4 @@
-import type { HTMLAttributes, ReactNode } from 'react';
+import React, { type HTMLAttributes, type ReactNode } from 'react';
 import cc from 'classcat';
 
 import { useStore } from '../../hooks/useStore';

--- a/packages/core/src/components/ReactFlowProvider/index.tsx
+++ b/packages/core/src/components/ReactFlowProvider/index.tsx
@@ -1,4 +1,4 @@
-import { useRef, type FC, type PropsWithChildren } from 'react';
+import React, { useRef, type FC, type PropsWithChildren } from 'react';
 import { StoreApi } from 'zustand';
 import { UseBoundStoreWithEqualityFn } from 'zustand/traditional';
 

--- a/packages/core/src/components/SelectionListener/index.tsx
+++ b/packages/core/src/components/SelectionListener/index.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect } from 'react';
+import React, { memo, useEffect } from 'react';
 import { shallow } from 'zustand/shallow';
 
 import { useStore, useStoreApi } from '../../hooks/useStore';

--- a/packages/core/src/components/UserSelection/index.tsx
+++ b/packages/core/src/components/UserSelection/index.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { shallow } from 'zustand/shallow';
 
 import { useStore } from '../../hooks/useStore';

--- a/packages/core/src/container/EdgeRenderer/MarkerDefinitions.tsx
+++ b/packages/core/src/container/EdgeRenderer/MarkerDefinitions.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback } from 'react';
+import React, { memo, useCallback } from 'react';
 
 import { useStore } from '../../hooks/useStore';
 import { getMarkerId } from '../../utils/graph';

--- a/packages/core/src/container/EdgeRenderer/MarkerSymbols.tsx
+++ b/packages/core/src/container/EdgeRenderer/MarkerSymbols.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import React, { useMemo } from 'react';
 
 import { MarkerType } from '../../types';
 import type { EdgeMarker } from '../../types';

--- a/packages/core/src/container/EdgeRenderer/index.tsx
+++ b/packages/core/src/container/EdgeRenderer/index.tsx
@@ -1,4 +1,4 @@
-import { memo, ReactNode } from 'react';
+import React, { memo, ReactNode } from 'react';
 import { shallow } from 'zustand/shallow';
 import cc from 'classcat';
 

--- a/packages/core/src/container/FlowRenderer/index.tsx
+++ b/packages/core/src/container/FlowRenderer/index.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import React, { memo } from 'react';
 import type { ReactNode } from 'react';
 
 import { useStore } from '../../hooks/useStore';

--- a/packages/core/src/container/GraphView/index.tsx
+++ b/packages/core/src/container/GraphView/index.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import React, { memo } from 'react';
 
 import FlowRenderer from '../FlowRenderer';
 import NodeRenderer from '../NodeRenderer';

--- a/packages/core/src/container/NodeRenderer/index.tsx
+++ b/packages/core/src/container/NodeRenderer/index.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo, useEffect, useRef } from 'react';
+import React, { memo, useMemo, useEffect, useRef } from 'react';
 import type { ComponentType } from 'react';
 import { shallow } from 'zustand/shallow';
 

--- a/packages/core/src/container/Pane/index.tsx
+++ b/packages/core/src/container/Pane/index.tsx
@@ -2,7 +2,7 @@
  * The user selection rectangle gets displayed when a user drags the mouse while pressing shift
  */
 
-import { memo, useRef, MouseEvent as ReactMouseEvent, ReactNode } from 'react';
+import React, { memo, useRef, MouseEvent as ReactMouseEvent, ReactNode } from 'react';
 import { shallow } from 'zustand/shallow';
 import cc from 'classcat';
 

--- a/packages/core/src/container/ReactFlow/Wrapper.tsx
+++ b/packages/core/src/container/ReactFlow/Wrapper.tsx
@@ -1,4 +1,4 @@
-import { useContext } from 'react';
+import React, { useContext } from 'react';
 import type { FC, PropsWithChildren } from 'react';
 
 import StoreContext from '../../contexts/RFStoreContext';

--- a/packages/core/src/container/ReactFlow/index.tsx
+++ b/packages/core/src/container/ReactFlow/index.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, type CSSProperties } from 'react';
+import React, { forwardRef, type CSSProperties } from 'react';
 import cc from 'classcat';
 
 import Attribution from '../../components/Attribution';

--- a/packages/core/src/container/Viewport/index.tsx
+++ b/packages/core/src/container/Viewport/index.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import React, { type ReactNode } from 'react';
 
 import { useStore } from '../../hooks/useStore';
 import type { ReactFlowState } from '../../types';

--- a/packages/core/src/container/ZoomPane/index.tsx
+++ b/packages/core/src/container/ZoomPane/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { zoom, zoomIdentity, type D3ZoomEvent, type ZoomTransform } from 'd3-zoom';
 import { select, pointer } from 'd3-selection';
 import { shallow } from 'zustand/shallow';

--- a/packages/minimap/package.json
+++ b/packages/minimap/package.json
@@ -20,7 +20,7 @@
   "exports": {
     ".": {
       "types": "./dist/esm/index.d.ts",
-      "import": "./dist/esm/index.js",
+      "import": "./dist/esm/index.mjs",
       "require": "./dist/umd/index.js"
     },
     "./dist/style.css": "./dist/style.css"

--- a/packages/minimap/src/MiniMap.tsx
+++ b/packages/minimap/src/MiniMap.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { memo, useEffect, useRef } from 'react';
+import React, { memo, useEffect, useRef } from 'react';
 import type { MouseEvent } from 'react';
 import cc from 'classcat';
 import { shallow } from 'zustand/shallow';
@@ -55,7 +55,7 @@ function MiniMap({
   ariaLabel = 'React Flow mini map',
   inversePan = false,
   zoomStep = 10,
-  offsetScale = 5
+  offsetScale = 5,
 }: MiniMapProps) {
   const store = useStoreApi();
   const svg = useRef<SVGSVGElement>(null);

--- a/packages/minimap/src/MiniMapNode.tsx
+++ b/packages/minimap/src/MiniMapNode.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import React, { memo } from 'react';
 import cc from 'classcat';
 
 import type { MiniMapNodeProps } from './types';

--- a/packages/minimap/src/MiniMapNodes.tsx
+++ b/packages/minimap/src/MiniMapNodes.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { memo } from 'react';
+import React, { memo } from 'react';
 import { shallow } from 'zustand/shallow';
 import { useStore, getNodePositionWithOrigin, type ReactFlowState } from '@reactflow/core';
 

--- a/packages/node-resizer/package.json
+++ b/packages/node-resizer/package.json
@@ -20,7 +20,7 @@
   "exports": {
     ".": {
       "types": "./dist/esm/index.d.ts",
-      "import": "./dist/esm/index.js",
+      "import": "./dist/esm/index.mjs",
       "require": "./dist/umd/index.js"
     },
     "./dist/style.css": "./dist/style.css"

--- a/packages/node-resizer/src/NodeResizer.tsx
+++ b/packages/node-resizer/src/NodeResizer.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import ResizeControl from './ResizeControl';
 import { ControlPosition, NodeResizerProps, ResizeControlVariant, ControlLinePosition } from './types';
 

--- a/packages/node-resizer/src/ResizeControl.tsx
+++ b/packages/node-resizer/src/ResizeControl.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, memo } from 'react';
+import React, { useRef, useEffect, memo } from 'react';
 import cc from 'classcat';
 import { drag } from 'd3-drag';
 import { select } from 'd3-selection';

--- a/packages/node-toolbar/package.json
+++ b/packages/node-toolbar/package.json
@@ -20,7 +20,7 @@
   "exports": {
     ".": {
       "types": "./dist/esm/index.d.ts",
-      "import": "./dist/esm/index.js",
+      "import": "./dist/esm/index.mjs",
       "require": "./dist/umd/index.js"
     }
   },

--- a/packages/node-toolbar/src/NodeToolbar.tsx
+++ b/packages/node-toolbar/src/NodeToolbar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, CSSProperties } from 'react';
+import React, { useCallback, CSSProperties } from 'react';
 import {
   Node,
   ReactFlowState,

--- a/packages/reactflow/package.json
+++ b/packages/reactflow/package.json
@@ -20,7 +20,7 @@
   "exports": {
     ".": {
       "types": "./dist/esm/index.d.ts",
-      "import": "./dist/esm/index.js",
+      "import": "./dist/esm/index.mjs",
       "require": "./dist/umd/index.js"
     },
     "./dist/base.css": "./dist/base.css",

--- a/tooling/eslint-config/src/index.js
+++ b/tooling/eslint-config/src/index.js
@@ -8,7 +8,6 @@ module.exports = {
   extends: [
     'eslint:recommended',
     'plugin:react/recommended',
-    'plugin:react/jsx-runtime',
     'plugin:@typescript-eslint/recommended',
     'turbo',
     'prettier',

--- a/tooling/rollup-config/src/index.js
+++ b/tooling/rollup-config/src/index.js
@@ -25,10 +25,10 @@ const onwarn = (warning, rollupWarn) => {
   }
 };
 
-export const esmConfig = defineConfig({
+const getEsmConfig = (format) => ({
   input: pkg.source,
   output: {
-    file: pkg.module,
+    file: format === 'js' ? pkg.module : pkg.module.replace('.js', '.mjs'),
     format: 'esm',
   },
   onwarn,
@@ -41,10 +41,12 @@ export const esmConfig = defineConfig({
   ],
 });
 
+export const esmJsConfig = defineConfig(getEsmConfig('js'));
+export const esmMjsConfig = defineConfig(getEsmConfig('mjs'));
+
 const globals = {
   react: 'React',
   'react-dom': 'ReactDOM',
-  'react/jsx-runtime': 'jsxRuntime',
   ...(pkg.rollup?.globals || {}),
 };
 
@@ -70,4 +72,4 @@ export const umdConfig = defineConfig({
   ],
 });
 
-export default isProd ? [esmConfig, umdConfig] : esmConfig;
+export default isProd ? [esmJsConfig, esmMjsConfig, umdConfig] : [esmMjsConfig];

--- a/tooling/tsconfig/react.json
+++ b/tooling/tsconfig/react.json
@@ -2,7 +2,7 @@
   "display": "ReactFlow Package",
   "extends": "./base.json",
   "compilerOptions": {
-    "jsx": "react-jsx",
+    "jsx": "react",
     "lib": ["dom", "esnext"],
     "module": "esnext",
     "target": "esnext",


### PR DESCRIPTION
This PR makes it possible to use React Flow with Astro, Remix and also older setups like webpack4 + React 17 for example. For this we had to replace "react-jsx" with "react" and also ship a legacy esm build for older setups.

Some context: 
* https://blog.isquaredsoftware.com/2023/08/esm-modernization-lessons/
* https://twitter.com/devongovett/status/1629161014812897282

Related issues: https://github.com/wbkd/react-flow/issues/3352, https://github.com/wbkd/react-flow/issues/3384, https://github.com/wbkd/react-flow/issues/3238