### PR TITLE
fix(delete-node): parentHit logic

### DIFF
--- a/packages/core/src/hooks/useReactFlow.ts
+++ b/packages/core/src/hooks/useReactFlow.ts
@@ -130,7 +130,17 @@ export default function useReactFlow<NodeData = any, EdgeData = any>(): ReactFlo
     const nodeIds = (nodesDeleted || []).map((node) => node.id);
     const edgeIds = (edgesDeleted || []).map((edge) => edge.id);
     const nodesToRemove = getNodes().reduce<Node[]>((res, node) => {
-      const parentHit = !nodeIds.includes(node.id) && node.parentNode && res.find((n) => n.id === node.parentNode);
+      let parentHit = false;
+      if(!nodeIds.includes(node.id)) {
+        let currentNode = node;
+        while (currentNode && currentNode.parentNode) {
+          if (nodeIds.includes(currentNode.parentNode)) {
+            parentHit = true;
+            break;
+          }
+          currentNode = getNodes().find((nd) => nd.id === currentNode.parentNode);
+        }
+      };
       const deletable = typeof node.deletable === 'boolean' ? node.deletable : true;
       if (deletable && (nodeIds.includes(node.id) || parentHit)) {
         res.push(node);


### PR DESCRIPTION
When node A in reactflow has the parentNode property, if the node B pointed to by parentNode has an index position greater than node A in the nodes array, an error will be thrown when node B is deleted: throw new Error(Parent node ${node.parentNode} not found).

 issue:  https://github.com/wbkd/react-flow/issues/3432

Ensure that parentHit is right regardless of the order of nodes.
```javascript
    const nodesToRemove = getNodes().reduce<Node[]>((res, node) => {
      let parentHit = false;
      if(!nodeIds.includes(node.id)) {
        let currentNode = node;
        while (currentNode && currentNode.parentNode) {
          if (nodeIds.includes(currentNode.parentNode)) {
            parentHit = true;
            break;
          }
          currentNode = getNodes().find((nd) => nd.id === currentNode.parentNode);
        }
      };
      const deletable = typeof node.deletable === 'boolean' ? node.deletable : true;
      if (deletable && (nodeIds.includes(node.id) || parentHit)) {
        res.push(node);
      }

      return res;
    }, []);

```