### PR TITLE
fix: calculation of target node center in examples

### DIFF
--- a/examples/vite-app/src/examples/EasyConnect/utils.tsx
+++ b/examples/vite-app/src/examples/EasyConnect/utils.tsx
@@ -9,15 +9,22 @@ function getNodeIntersection(intersectionNode: Node, targetNode: Node) {
     height: intersectionNodeHeight,
     positionAbsolute: intersectionNodePosition,
   } = intersectionNode;
-  const targetPosition = targetNode.positionAbsolute!;
+
+  const {
+    width: targetNodeWidth,
+    height: targetNodeHeight,
+    positionAbsolute: targetNodePosition,
+  } = targetNode;
 
   const w = intersectionNodeWidth! / 2;
   const h = intersectionNodeHeight! / 2;
+  const targetW = targetNodeWidth! / 2
+  const targetH = targetNodeHeight! / 2
 
   const x2 = intersectionNodePosition!.x + w;
   const y2 = intersectionNodePosition!.y + h;
-  const x1 = targetPosition.x + w;
-  const y1 = targetPosition.y + h;
+  const x1 = targetNodePosition.x + targetW;
+  const y1 = targetNodePosition.y + targetH;
 
   const xx1 = (x1 - x2) / (2 * w) - (y1 - y2) / (2 * h);
   const yy1 = (x1 - x2) / (2 * w) + (y1 - y2) / (2 * h);

--- a/examples/vite-app/src/examples/FloatingEdges/utils.ts
+++ b/examples/vite-app/src/examples/FloatingEdges/utils.ts
@@ -10,15 +10,22 @@ function getNodeIntersection(intersectionNode: Node, targetNode: Node): XYPositi
     height: intersectionNodeHeight,
     position: intersectionNodePosition,
   } = intersectionNode;
-  const targetPosition = targetNode.position;
+
+  const {
+    width: targetNodeWidth,
+    height: targetNodeHeight,
+    positionAbsolute: targetNodePosition,
+  } = targetNode;
 
   const w = (intersectionNodeWidth ?? 0) / 2;
   const h = (intersectionNodeHeight ?? 0) / 2;
+  const targetW = (targetNodeWidth ?? 0) / 2
+  const targetH = (targetNodeHeight ?? 0) / 2
 
   const x2 = intersectionNodePosition.x + w;
   const y2 = intersectionNodePosition.y + h;
-  const x1 = targetPosition.x + w;
-  const y1 = targetPosition.y + h;
+  const x1 = targetNodePosition.x + targetW;
+  const y1 = targetNodePosition.y + targetH;
 
   const xx1 = (x1 - x2) / (2 * w) - (y1 - y2) / (2 * h);
   const yy1 = (x1 - x2) / (2 * w) + (y1 - y2) / (2 * h);


### PR DESCRIPTION
Hello Team!

While reviewing the changes introduced in the recent commit for the `getNodeIntersection` function, I've identified a critical concern related to how the coordinates are being calculated for `x1` and `y1`. This miscalculation could lead to inaccuracies in the resultant intersection point.

**Issue:**
In the current implementation, `x1` and `y1` are calculated using the `targetNodePosition` coordinates plus `w` and `h` variables, which represent half of the `intersectionNode`'s dimensions. This calculation assumes that the dimensions of `targetNode` and `intersectionNode` are the same, which might not always be the case. Adding `w` and `h` from the `intersectionNode` to the `targetNode`'s position offsets the target's actual center point, likely leading to an incorrect intersection calculation.

**Proposed Solution:**
To rectify this, we need to calculate `x1` and `y1` based on the actual dimensions of the `targetNode`. Extract the width and height properties from the `targetNode`. Calculate the center of the `targetNode` using its dimensions.

Thank you!