### PR TITLE
Enhance fitViewOptions

### DIFF
--- a/examples/react/src/examples/Basic/index.tsx
+++ b/examples/react/src/examples/Basic/index.tsx
@@ -147,8 +147,7 @@ const BasicFlow = () => {
       maxZoom={4}
       fitView
       fitViewOptions={{
-        // top, right, bottom, left
-        padding: ['100px', '0%', '0%', '50px'],
+        padding: { top: '100px', left: '0%', right: '10%', bottom: 0.1 },
       }}
       defaultEdgeOptions={defaultEdgeOptions}
       selectNodesOnDrag={false}

--- a/packages/system/src/types/general.ts
+++ b/packages/system/src/types/general.ts
@@ -96,15 +96,14 @@ export type PaddingWithUnit = `${number}${PaddingUnit}` | number;
 
 export type Padding =
   | PaddingWithUnit
-  | [padding: PaddingWithUnit]
-  | [paddingY: PaddingWithUnit, paddingX: PaddingWithUnit]
-  | [paddingTop: PaddingWithUnit, paddingX: PaddingWithUnit, paddingBottom: PaddingWithUnit]
-  | [
-      paddingTop: PaddingWithUnit,
-      paddingRight: PaddingWithUnit,
-      paddingBottom: PaddingWithUnit,
-      paddingLeft: PaddingWithUnit
-    ];
+  | {
+      top?: PaddingWithUnit;
+      right?: PaddingWithUnit;
+      bottom?: PaddingWithUnit;
+      left?: PaddingWithUnit;
+      x?: PaddingWithUnit;
+      y?: PaddingWithUnit;
+    };
 
 /**
  * @inline


### PR DESCRIPTION
You are now able to pass `paddingUnit: '%' | 'px'` and an seperate horizontal and vertical paddings `padding: [number, number]` as `fitViewOptions`.

## Checklist
 
- [x] express padding in pixels #4754 
- [x] add option to avoid centering #5050
- [x] allow `padding: [number, number, number, number]`