### PR TITLE
perf: improve pane dragging render performance

### DIFF
--- a/packages/react/src/container/Pane/index.tsx
+++ b/packages/react/src/container/Pane/index.tsx
@@ -265,7 +265,7 @@ export function Pane({
 
   return (
     <div
-      className={cc(['react-flow__pane', { draggable, dragging, selection: isSelecting }])}
+      className={cc(['react-flow__pane', { selection: isSelecting }])}
       onClick={hasActiveSelection ? undefined : wrapHandler(onClick, container)}
       onContextMenu={wrapHandler(onContextMenu, container)}
       onWheel={wrapHandler(onWheel, container)}
@@ -278,6 +278,7 @@ export function Pane({
       style={containerStyle}
     >
       {children}
+      {draggable && <div className={cc(['react-flow__drag', 'react-flow__container', { dragging }])}></div>}
       <UserSelection />
     </div>
   );

--- a/packages/svelte/src/lib/container/Pane/Pane.svelte
+++ b/packages/svelte/src/lib/container/Pane/Pane.svelte
@@ -221,8 +221,6 @@
 <div
   bind:this={container}
   class="svelte-flow__pane svelte-flow__container"
-  class:draggable={panOnDrag === true || (Array.isArray(panOnDrag) && panOnDrag.includes(0))}
-  class:dragging={store.dragging}
   class:selection={isSelecting}
   onclick={hasActiveSelection ? undefined : wrapHandler(onClick, container)}
   onpointerdown={hasActiveSelection ? onPointerDown : undefined}
@@ -231,4 +229,7 @@
   oncontextmenu={wrapHandler(onContextMenu, container)}
 >
   {@render children()}
+  {#if panOnDrag === true || (Array.isArray(panOnDrag) && panOnDrag.includes(0))}
+    <div class="svelte-flow__drag svelte-flow__container" class:dragging={store.dragging}></div>
+  {/if}
 </div>

--- a/packages/system/src/styles/init.css
+++ b/packages/system/src/styles/init.css
@@ -69,16 +69,16 @@
 .xy-flow__pane {
   z-index: 1;
 
-  &.draggable {
-    cursor: grab;
+  &.selection {
+    cursor: pointer;
   }
+}
+
+.xy-flow__drag {
+  cursor: grab;
 
   &.dragging {
     cursor: grabbing;
-  }
-
-  &.selection {
-    cursor: pointer;
   }
 }
 


### PR DESCRIPTION
Currently, when dragging/clicking a pane, the pane element will add a `dragging` class to change the cursor style property from grab to grabbing. As the number of nodes (in other words: the amount of DOM) increases, the time it takes to recalculate the style increases, especially on Chromium-based browsers. There is a known chromium issue here that reveals that modifying the cursor style can cause this problem: https://issues.chromium.org/issues/40493007

So I applied this style change to a single div to avoid recalculating styles for a large number of elements.

This might help resolve the issue: https://github.com/xyflow/xyflow/issues/4527