### PR TITLE
feat: Add ability to controll selection state externally

### DIFF
--- a/.changeset/chilled-oranges-turn.md
+++ b/.changeset/chilled-oranges-turn.md
@@ -1,0 +1,5 @@
+---
+'@xyflow/react': major
+---
+
+Add ability to controll selection state externally

--- a/packages/react/src/container/FlowRenderer/index.tsx
+++ b/packages/react/src/container/FlowRenderer/index.tsx
@@ -44,6 +44,7 @@ function FlowRendererComponent<NodeType extends Node = Node>({
   onPaneScroll,
   paneClickDistance,
   deleteKeyCode,
+  selecting,
   selectionKeyCode,
   selectionOnDrag,
   selectionMode,
@@ -79,7 +80,7 @@ function FlowRendererComponent<NodeType extends Node = Node>({
   const panOnDrag = panActivationKeyPressed || _panOnDrag;
   const panOnScroll = panActivationKeyPressed || _panOnScroll;
   const _selectionOnDrag = selectionOnDrag && panOnDrag !== true;
-  const isSelecting = selectionKeyPressed || userSelectionActive || _selectionOnDrag;
+  const isSelecting = selectionKeyPressed || userSelectionActive || _selectionOnDrag || selecting;
 
   useGlobalKeyHandler({ deleteKeyCode, multiSelectionKeyCode });
 
@@ -93,7 +94,7 @@ function FlowRendererComponent<NodeType extends Node = Node>({
       panOnScrollSpeed={panOnScrollSpeed}
       panOnScrollMode={panOnScrollMode}
       zoomOnDoubleClick={zoomOnDoubleClick}
-      panOnDrag={!selectionKeyPressed && panOnDrag}
+      panOnDrag={!selectionKeyPressed && !selecting && panOnDrag}
       defaultViewport={defaultViewport}
       translateExtent={translateExtent}
       minZoom={minZoom}
@@ -118,7 +119,7 @@ function FlowRendererComponent<NodeType extends Node = Node>({
         panOnDrag={panOnDrag}
         isSelecting={!!isSelecting}
         selectionMode={selectionMode}
-        selectionKeyPressed={selectionKeyPressed}
+        selectionKeyPressed={selectionKeyPressed || !!selecting}
         selectionOnDrag={_selectionOnDrag}
       >
         {children}

--- a/packages/react/src/container/GraphView/index.tsx
+++ b/packages/react/src/container/GraphView/index.tsx
@@ -58,6 +58,7 @@ function GraphViewComponent<NodeType extends Node = Node, EdgeType extends Edge 
   connectionLineStyle,
   connectionLineComponent,
   connectionLineContainerStyle,
+  selecting,
   selectionKeyCode,
   selectionOnDrag,
   selectionMode,
@@ -122,6 +123,7 @@ function GraphViewComponent<NodeType extends Node = Node, EdgeType extends Edge 
       onPaneScroll={onPaneScroll}
       paneClickDistance={paneClickDistance}
       deleteKeyCode={deleteKeyCode}
+      selecting={selecting}
       selectionKeyCode={selectionKeyCode}
       selectionOnDrag={selectionOnDrag}
       selectionMode={selectionMode}

--- a/packages/react/src/container/ReactFlow/index.tsx
+++ b/packages/react/src/container/ReactFlow/index.tsx
@@ -66,6 +66,7 @@ function ReactFlow<NodeType extends Node = Node, EdgeType extends Edge = Edge>(
     connectionLineComponent,
     connectionLineContainerStyle,
     deleteKeyCode = 'Backspace',
+    selecting,
     selectionKeyCode = 'Shift',
     selectionOnDrag = false,
     selectionMode = SelectionMode.Full,
@@ -202,6 +203,7 @@ function ReactFlow<NodeType extends Node = Node, EdgeType extends Edge = Edge>(
           connectionLineStyle={connectionLineStyle}
           connectionLineComponent={connectionLineComponent}
           connectionLineContainerStyle={connectionLineContainerStyle}
+          selecting={selecting}
           selectionKeyCode={selectionKeyCode}
           selectionOnDrag={selectionOnDrag}
           selectionMode={selectionMode}

--- a/packages/react/src/types/component-props.ts
+++ b/packages/react/src/types/component-props.ts
@@ -326,6 +326,8 @@ export interface ReactFlowProps<NodeType extends Node = Node, EdgeType extends E
    * @default 'Backspace'
    */
   deleteKeyCode?: KeyCode | null;
+  /** This flag indicates if the user is currently selecting elements. */
+  selecting?: boolean;
   /**
    * If set, holding this key will let you click and drag to draw a selection box around multiple
    * nodes and edges. Passing an array represents multiple keys that can be pressed.


### PR DESCRIPTION
## Summary
This PR introduces a new `selecting` prop to React Flow that allows developers to programmatically toggle selection mode without requiring users to hold down a key.

## Motivation
Currently, React Flow only supports box selection when the user holds a modifier key. While this works well on desktop, it can be cumbersome on laptops.  

We want to implement a toolbar with two buttons: **Pan** and **Box select**. Clicking "Select" enables selection mode in React Flow without requiring the user to hold `Shift`.