### PR TITLE
chore(license): happy new year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019-2024 webkid GmbH
+Copyright (c) 2019-2025 webkid GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This pull request updates the copyright year in the `LICENSE` file to reflect the current year.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the license notice year to 2019–2025 to keep legal information current.

* **Documentation**
  * Refreshed licensing details to reflect the current year.
  * No changes to license terms or application behavior; purely an administrative update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->