### PR TITLE
fix nodeClickDistance

### DIFF
--- a/examples/react/src/examples/Basic/index.tsx
+++ b/examples/react/src/examples/Basic/index.tsx
@@ -162,7 +162,8 @@ const BasicFlow = () => {
         selectNodesOnDrag={false}
         elevateEdgesOnSelect
         elevateNodesOnSelect={false}
-        nodeDragThreshold={0}
+        nodeDragThreshold={5}
+        nodeClickDistance={Infinity}
       >
         <Background variant={BackgroundVariant.Dots} />
         <MiniMap />

--- a/packages/system/src/xydrag/XYDrag.ts
+++ b/packages/system/src/xydrag/XYDrag.ts
@@ -341,9 +341,9 @@ export function XYDrag<OnNodeDrag extends (e: any, nodes: any, node: any) => voi
         if (!dragStarted) {
           // Calculate distance in client coordinates for consistent drag threshold behavior across zoom levels
           const currentMousePosition = getEventPosition(event.sourceEvent, containerBounds!);
-          const x = currentMousePosition.x - initialMousePosition.x;
-          const y = currentMousePosition.y - initialMousePosition.y;
-          const distance = Math.sqrt(x * x + y * y);
+          const dx = currentMousePosition.x - initialMousePosition.x;
+          const dy = currentMousePosition.y - initialMousePosition.y;
+          const distance = Math.hypot(dx, dy);
 
           if (distance > nodeDragThreshold) {
             startDrag(event);


### PR DESCRIPTION
closes #5204 and to an extent #4996


2 things changed:
- We calculate the nodeClickDistance ourselves in clientCoordinates
- We always prevent clicks when a node position has changed


This leads to a much better default especially in connection with `snapGrid`.  You can simply set the `nodeClickDistance` to `Infinity` which leads to nodeClickEvents always firing when the node has not moved. This way you don't even have to rely on some arbitrary number but can just let your `snapGrid` control it implicitly.

I would argue you NEVER want to fire click events after dragging has commenced.  ~~We might want to check this assumption based on the how things like `draggable` handle this~~. This is the same behavior as `draggable` html elements have. 


The question remains if we shouldn't just remove nodeClickDistance, because nodeDragThreshold should be the sole value controlling this behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliably distinguish clicks from drags to prevent accidental activations.
  * Suppress unintended clicks during or immediately after dragging and ensure the click blocker is removed on teardown.
  * Capture initial pointer position for smoother, more accurate drag detection.

* **New Features / Behavior Changes**
  * Increased drag sensitivity (node drag threshold raised to 5) and disabled click activation by distance (node click distance set to Infinity).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->