### PR TITLE
Define strict type for EdgeProps.pathOptions

### DIFF
--- a/packages/react/src/types/edges.ts
+++ b/packages/react/src/types/edges.ts
@@ -61,6 +61,8 @@ type StepEdge<EdgeData extends Record<string, unknown> = Record<string, unknown>
 
 type StraightEdge<EdgeData extends Record<string, unknown> = Record<string, unknown>> = Edge<EdgeData, 'straight'>;
 
+type InferPathOptions<E extends Edge> = E extends { pathOptions?: infer P } ? P : any;
+
 export type BuiltInEdge = SmoothStepEdge | BezierEdge | StepEdge | StraightEdge;
 
 export type EdgeMouseHandler<EdgeType extends Edge = Edge> = (event: ReactMouseEvent, edge: EdgeType) => void;
@@ -114,8 +116,7 @@ export type EdgeProps<EdgeType extends Edge = Edge> = Pick<
     targetHandleId?: string | null;
     markerStart?: string;
     markerEnd?: string;
-    // @TODO: how can we get better types for pathOptions?
-    pathOptions?: any;
+    pathOptions?: InferPathOptions<EdgeType>;
     interactionWidth?: number;
   };
 


### PR DESCRIPTION
## Summary
Improves type safety for the `pathOptions` prop in `EdgeProps` by replacing the `any` type with a new `InferPathOptions` utility type that properly infers the path options from the edge type.

## Changes
- Added `InferPathOptions<E>` utility type that extracts the `pathOptions` type from an edge
- Updated `EdgeProps.pathOptions` to use `InferPathOptions<EdgeType>` instead of `any`
- Removed the TODO comment about improving types for `pathOptions`

## Example
With the updated typing, custom edges automatically provide strongly typed pathOptions.
For example:

```Typescript
type CustomEdgeType = Edge<CustomEdgeData> & {
  pathOptions?: {
    color: string;
  };
};
```

When using EdgeProps<CustomEdgeType>, the pathOptions property is now inferred as:

```Typescript
pathOptions?: { color: string };
```

This ensures that consumers get accurate autocomplete and type checking for their custom edge options.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced TypeScript type definitions for edge configurations, enabling improved IDE autocompletion and stricter compile-time type checking for path options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->