### PR TITLE
handle undefined node in NodeComponentWrapperInner

### DIFF
--- a/packages/react/src/additional-components/MiniMap/MiniMapNodes.tsx
+++ b/packages/react/src/additional-components/MiniMap/MiniMapNodes.tsx
@@ -84,7 +84,10 @@ function NodeComponentWrapperInner<NodeType extends Node>({
   shapeRendering: string;
 }) {
   const { node, x, y, width, height } = useStore((s) => {
-    const { internals } = s.nodeLookup.get(id)!;
+    const internals = s.nodeLookup.get(id)?.internals;
+    if (!internals) {
+      return { node: undefined, x: 0, y: 0, width: 0, height: 0 };
+    }
     const node = internals.userNode as NodeType;
     const { x, y } = internals.positionAbsolute;
     const { width, height } = getNodeDimensions(node);


### PR DESCRIPTION
This PR attempts to fix #5651.
It seems that when ReactFlow unmounts, the store gets reset and nodeLookup is cleared. The MiniMap selector appears to still run one more time against the empty lookup, and the non-null assertion on nodeLookup.get(id)! throws.
The bug was likely already present, recent changes probably just shifted timing enough to expose it. (maybe the rerender optimization in #5629 or maybe some dependency update)

The fix:
Added optional chaining and an early return with safe defaults in the selector. The existing if (!node) guard already handles this case, it just wasn't being reached because the selector threw first.
