### PR TITLE
feat(node-resizer): add shift aspect lock and alt for symmetric resize

### DIFF
--- a/packages/system/src/xyresizer/XYResizer.ts
+++ b/packages/system/src/xyresizer/XYResizer.ts
@@ -234,12 +234,17 @@ export function XYResizer({ domNode, nodeId, getStoreItems, onChange, onEnd }: X
         const change: XYResizerChange = {};
         const nodeOrigin = node.origin ?? storeNodeOrigin;
 
+        const isCornerControl = params.controlDirection.isHorizontal && params.controlDirection.isVertical;
+        const shouldKeepAspectRatio = params.keepAspectRatio || (isCornerControl && event.sourceEvent.shiftKey);
+        const shouldSymmetricResize = event.sourceEvent.altKey;
+
         const { width, height, x, y } = getDimensionsAfterResize(
           startValues,
           params.controlDirection,
           pointerPosition,
           params.boundaries,
-          params.keepAspectRatio,
+          shouldKeepAspectRatio,
+          shouldSymmetricResize,
           nodeOrigin,
           parentExtent,
           childExtent

--- a/packages/system/src/xyresizer/utils.ts
+++ b/packages/system/src/xyresizer/utils.ts
@@ -117,6 +117,7 @@ export function getDimensionsAfterResize(
   pointerPosition: ReturnType<typeof getPointerPosition>,
   boundaries: { minWidth: number; maxWidth: number; minHeight: number; maxHeight: number },
   keepAspectRatio: boolean,
+  symmetricResize: boolean,
   nodeOrigin: NodeOrigin,
   extent?: CoordinateExtent,
   childExtent?: CoordinateExtent
@@ -131,6 +132,15 @@ export function getDimensionsAfterResize(
   const { x: startX, y: startY, width: startWidth, height: startHeight, aspectRatio } = startValues;
   let distX = Math.floor(isHorizontal ? xSnapped - startValues.pointerX : 0);
   let distY = Math.floor(isVertical ? ySnapped - startValues.pointerY : 0);
+
+  if (symmetricResize) {
+    if (isHorizontal) {
+      distX = distX * 2;
+    }
+    if (isVertical) {
+      distY = distY * 2;
+    }
+  }
 
   const newWidth = startWidth + (affectsX ? -distX : distX);
   const newHeight = startHeight + (affectsY ? -distY : distY);
@@ -271,10 +281,23 @@ export function getDimensionsAfterResize(
   const x = affectsX ? startX + distX : startX;
   const y = affectsY ? startY + distY : startY;
 
-  return {
+  const dimensions = {
     width: startWidth + (affectsX ? -distX : distX),
     height: startHeight + (affectsY ? -distY : distY),
     x: nodeOrigin[0] * distX * (!affectsX ? 1 : -1) + x,
     y: nodeOrigin[1] * distY * (!affectsY ? 1 : -1) + y,
+  };
+
+  if (!symmetricResize) {
+    return dimensions;
+  }
+
+  const centerX = startX + (0.5 - nodeOrigin[0]) * startWidth;
+  const centerY = startY + (0.5 - nodeOrigin[1]) * startHeight;
+
+  return {
+    ...dimensions,
+    x: centerX - (0.5 - nodeOrigin[0]) * dimensions.width,
+    y: centerY - (0.5 - nodeOrigin[1]) * dimensions.height,
   };
 }


### PR DESCRIPTION
Adds shift to lock aspect ratio (corner controls) and alt‑key symmetric resize for XYResizer (feature request #5552).