### PR TITLE
fix(system): fire onNodeDrag even when nodeExtent clamps position

### DIFF
--- a/.changeset/fix-node-drag-on-clamped-extent.md
+++ b/.changeset/fix-node-drag-on-clamped-extent.md
@@ -1,0 +1,7 @@
+---
+'@xyflow/system': patch
+'@xyflow/react': patch
+'@xyflow/svelte': patch
+---
+
+Fix `onNodeDrag` not being called when `nodeExtent` clamps position on both axes

--- a/packages/system/src/xydrag/XYDrag.ts
+++ b/packages/system/src/xydrag/XYDrag.ts
@@ -197,11 +197,9 @@ export function XYDrag<OnNodeDrag extends (e: any, nodes: any, node: any) => voi
 
       nodePositionsChanged = nodePositionsChanged || hasChange;
 
-      if (!hasChange) {
-        return;
+      if (hasChange) {
+        updateNodePositions(dragItems, true);
       }
-
-      updateNodePositions(dragItems, true);
 
       if (dragEvent && (onDrag || onNodeDrag || (!nodeId && onSelectionDrag))) {
         const [currentNode, currentNodes] = getEventHandlerParams({


### PR DESCRIPTION
## Summary

Fixes #5706

**Live reproduction:** https://xyflow-nodeextent-bug.vercel.app
**Source:** https://github.com/jiwonMe/xyflow-nodeextent-bug

When `nodeExtent` clamps a dragged node's position on both axes simultaneously (e.g., dragging into a corner), `onNodeDrag` stops firing entirely. This is because the `hasChange` early return in `updateNodes()` gates both the position update AND the drag callbacks.

## The Problem

In `XYDrag.ts`, `updateNodes()`:

```typescript
// Before (bug)
if (!hasChange) {
  return; // skips BOTH updateNodePositions AND onNodeDrag
}

updateNodePositions(dragItems, true);
onNodeDrag?.(dragEvent, currentNode, currentNodes); // never reached
```

When `calculateNodePosition()` returns the same clamped coordinates as the previous frame, `hasChange` stays `false` → early return → `onNodeDrag` never fires.

## The Fix

Split the guard so `updateNodePositions` is correctly skipped when there is no position change, but drag callbacks always fire during an active drag:

```typescript
// After (fix)
if (hasChange) {
  updateNodePositions(dragItems, true);
}

// Always fire - the drag event is still happening
onNodeDrag?.(dragEvent, currentNode, currentNodes);
```

This is a 3-line change.

## Why This Matters

Consumers use `onNodeDrag` for more than just position tracking:

- **Cross-boundary detection**: Is the cursor outside a container? (nested ReactFlow use case)
- **Ghost/preview rendering**: Rendering a drag preview at cursor position
- **Drop target detection**: Highlighting drop zones based on cursor, not node position

These all depend on the `event.clientX/clientY` from the MouseEvent, which keeps changing even when the node position is clamped.

## Consistency

This aligns with how `onNodeDragStop` already works - it fires regardless of whether positions changed (guarded by `nodePositionsChanged`, not `hasChange`).

## Testing

- Build passes (`pnpm build`)
- Existing Playwright tests: same results as `main` (43 pre-existing webkit failures unrelated to this change)
