### PR TITLE
fix(react): allow pointer events on viewport and nodes for interactive custom nodes

### DIFF
--- a/packages/system/src/styles/init.css
+++ b/packages/system/src/styles/init.css
@@ -85,7 +85,7 @@
 .xy-flow__viewport {
   transform-origin: 0 0;
   z-index: 2;
-  pointer-events: none;
+  pointer-events: auto;
 }
 
 .xy-flow__renderer {
@@ -191,7 +191,7 @@ svg.xy-flow__connectionline {
 }
 
 .xy-flow__nodes {
-  pointer-events: none;
+  pointer-events: auto;
   transform-origin: 0 0;
 }
 


### PR DESCRIPTION
## Problem

When using custom nodes with interactive content (inputs, selects, buttons), the default library CSS sets `.react-flow__viewport` and `.react-flow__nodes` to `pointer-events: none`. Hit-testing then falls through to the pane, which causes:

- The pane/viewport to receive hover and click instead of the node
- Dropdowns and inputs inside nodes to be hard or impossible to click
- The cursor to show grab over the whole canvas instead of default/pointer over controls

## Solution

In the shared style source used by `@xyflow/react` (`packages/system/src/styles/init.css`), both selectors are set to `pointer-events: auto`:

- **`.xy-flow__viewport`** → `pointer-events: auto` — so the viewport can receive events for panning and the empty canvas keeps the grab cursor
- **`.xy-flow__nodes`** → `pointer-events: auto` — so nodes and their children (inputs, buttons, etc.) receive clicks and hover correctly

## Backward compatibility

Apps that depend on the previous behavior can override back to `pointer-events: none` on these classes in their own CSS.