### PR TITLE
Fix #2248: useKeyPress doesn't track repeated combination keypresses un

### DIFF
--- a/packages/react/src/hooks/useKeyPress.ts
+++ b/packages/react/src/hooks/useKeyPress.ts
@@ -130,10 +130,9 @@ export function useKeyPress(
 
         if (isMatchingKey(keyCodes, pressedKeys.current, true)) {
           setKeyPressed(false);
-          pressedKeys.current.clear();
-        } else {
-          pressedKeys.current.delete(event[keyOrCode]);
         }
+
+        pressedKeys.current.delete(event[keyOrCode]);
 
         // fix for Mac: when cmd key is pressed, keyup is not triggered for any other key, see: https://stackoverflow.com/questions/27380018/when-cmd-key-is-kept-pressed-keyup-is-not-triggered-for-any-other-key
         if (event.key === 'Meta') {


### PR DESCRIPTION
Fixes #2248

## Summary
This PR addresses: useKeyPress doesn't track repeated combination keypresses until the entire combination is released

## Changes
```
packages/react/src/hooks/useKeyPress.ts | 5 ++---
 1 file changed, 2 insertions(+), 3 deletions(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*