### PR TITLE
Explicitly allow missing `type` field in BuiltInNode type definition

### DIFF
--- a/.changeset/allow-undefined-builtin-node-type.md
+++ b/.changeset/allow-undefined-builtin-node-type.md
@@ -1,0 +1,6 @@
+---
+"@xyflow/react": patch
+"@xyflow/svelte": patch
+---
+
+Allow `type` field to be missing in `BuiltInNode` (no `type` field is the same as `type: "default"`)

--- a/packages/react/src/types/nodes.ts
+++ b/packages/react/src/types/nodes.ts
@@ -93,7 +93,7 @@ export type NodeWrapperProps<NodeType extends Node> = {
  * ```
  */
 export type BuiltInNode =
-  | Node<{ label: string }, 'input' | 'output' | 'default'>
+  | Node<{ label: string }, 'input' | 'output' | 'default' | undefined>
   | Node<Record<string, never>, 'group'>;
 
 /**

--- a/packages/svelte/src/lib/types/nodes.ts
+++ b/packages/svelte/src/lib/types/nodes.ts
@@ -63,5 +63,5 @@ export type NodeTypes = Record<
 >;
 
 export type BuiltInNode =
-  | Node<{ label: string }, 'input' | 'output' | 'default'>
+  | Node<{ label: string }, 'input' | 'output' | 'default' | undefined>
   | Node<Record<string, never>, 'group'>;


### PR DESCRIPTION
This improves the DX in cases like this:

```ts
const initialNodes: BuiltInNode[] = [
//                  ~~~~~~~~~~~~~
//                   TS error here currently, because these nodes
//                   don't explicitly set `type: "default"`
  { id: "1", position: { x: 0, y: 0 }, data: { label: "Node 1" } },
  { id: "2", position: { x: 100, y: 100 }, data: { label: "Node 2" } },
];
```
